### PR TITLE
[Fix/#144] add padding to item

### DIFF
--- a/feature/my/src/main/java/com/hankki/feature/my/component/StoreItem.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/component/StoreItem.kt
@@ -55,8 +55,7 @@ fun StoreItem(
             .wrapContentHeight()
             .clip(RoundedCornerShape(10.dp))
             .background(White)
-            .padding(vertical = 16.dp),
-            //.noRippleClickable(onClickItem),
+            .padding(vertical = 16.dp, horizontal = 22.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         AsyncImage(

--- a/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
@@ -200,10 +200,11 @@ fun MyJogboDetailScreen(
 
         when (storeItems) {
             is EmptyUiState.Loading -> {
-                Box(modifier = Modifier
-                    .fillMaxSize()
-                    .background(White)
-                ){
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(White)
+                ) {
                     CircleLoadingScreen()
                 }
             }
@@ -212,15 +213,14 @@ fun MyJogboDetailScreen(
                 LazyColumn(
                     modifier = Modifier
                         .fillMaxSize()
-                        .background(White)
-                        .padding(horizontal = 22.dp),
+                        .background(White),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     item {
                         Spacer(modifier = Modifier.height(4.dp))
                     }
 
-                    items(storeItems .data) { store ->
+                    items(storeItems.data) { store ->
                         StoreItem(
                             imageUrl = store.imageUrl,
                             category = store.category,


### PR DESCRIPTION
- closed #144

## *⛳️ Work Description*
- 기존 화면의 padding을 없애고 아이템의 padding을 추가하였습니다

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

|전|후 (ripple 영역 확대)|
|:---:|:---:|
|<img src="https://github.com/user-attachments/assets/7874da08-e3ef-4a1d-920a-b681b408addf" width=270 />|<img src="https://github.com/user-attachments/assets/bfd909ea-833d-4a1d-9a7a-7c6d210d2b80" width=270 />|

## *📢 To Reviewers*
- 이슈에 "좋아요 누른/내가 제보한 식당 리스트 없을때 이미지 내려가는 오류 수정" todo가 있었는데 알고보니 이 부분은 네비와 연관이 있어서 추후에 시도해야할 것 같습니다 :)
- 궁금한 점 : 이것도 fix 라벨 달아야하나요?
