### PR TITLE
[Feature/#151] Move to store

### DIFF
--- a/feature/my/src/main/java/com/hankki/feature/my/component/JogboFolder.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/component/JogboFolder.kt
@@ -35,7 +35,7 @@ import kotlinx.collections.immutable.PersistentList
 fun JogboFolder(
     title: String,
     chips: PersistentList<String>,
-    userName: String,
+    userNickname: String,
     shareJogbo: () -> Unit,
 ) {
     Box(
@@ -95,7 +95,7 @@ fun JogboFolder(
                         modifier = Modifier.size(26.dp)
                     )
                     Text(
-                        text = userName,
+                        text = userNickname,
                         style = HankkiTheme.typography.body4,
                         color = Gray600,
                         modifier = Modifier.padding(start = 8.dp)

--- a/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
@@ -105,7 +105,7 @@ fun MyJogboDetailRoute(
         },
         selectedStoreId = myJogboDetailState.selectedStoreId,
         updateSelectedStoreId = { storeId -> myJogboDetailViewModel.updateSelectedStoreId(storeId) },
-        onClickStoreItem = { storeId -> myJogboDetailViewModel.onClickStoreItem(storeId) },
+        navigateToStoreDetail = myJogboDetailViewModel::navigateToStoreDetail,
         userName = myJogboDetailState.userInformation.nickname,
         navigateToHome = myJogboDetailViewModel::navigateToHome
     )
@@ -127,7 +127,7 @@ fun MyJogboDetailScreen(
     deleteJogboStore: (Long) -> Unit,
     selectedStoreId: Long,
     updateSelectedStoreId: (Long) -> Unit,
-    onClickStoreItem: (Long) -> Unit,
+    navigateToStoreDetail: (Long) -> Unit,
     userName: String,
     navigateToHome: () -> Unit,
 ) {
@@ -231,7 +231,7 @@ fun MyJogboDetailScreen(
                             isIconUsed = false,
                             isIconSelected = false,
                             modifier = Modifier.combinedClickable(
-                                onClick = { onClickStoreItem(store.id) },
+                                onClick = { navigateToStoreDetail(store.id) },
                                 onLongClick = {
                                     updateSelectedStoreId(store.id)
                                     updateDeleteDialogState()

--- a/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
@@ -51,7 +51,6 @@ import com.hankki.core.designsystem.theme.HankkijogboTheme
 import com.hankki.core.designsystem.theme.Red
 import com.hankki.core.designsystem.theme.White
 import com.hankki.domain.my.entity.response.Store
-import com.hankki.domain.my.entity.response.UserInformationEntity
 import com.hankki.feature.my.R
 import com.hankki.feature.my.component.EmptyStoreView
 import com.hankki.feature.my.component.JogboFolder
@@ -94,7 +93,7 @@ fun MyJogboDetailRoute(
         storeItems = myJogboDetailState.storesUiState,
         deleteDialogState = myJogboDetailState.showDeleteDialog,
         shareDialogState = myJogboDetailState.showShareDialog,
-        userInformation = myJogboDetailState.userInformation,
+        userNickname = myJogboDetailState.userInformation.nickname,
         updateShareDialogState = { myJogboDetailViewModel.updateShareDialog(myJogboDetailState.showShareDialog) },
         updateDeleteDialogState = { myJogboDetailViewModel.updateDeleteDialog(myJogboDetailState.showDeleteDialog) },
         deleteJogboStore = { storeId ->
@@ -106,7 +105,6 @@ fun MyJogboDetailRoute(
         selectedStoreId = myJogboDetailState.selectedStoreId,
         updateSelectedStoreId = myJogboDetailViewModel::updateSelectedStoreId,
         navigateToStoreDetail = myJogboDetailViewModel::navigateToStoreDetail,
-        userName = myJogboDetailState.userInformation.nickname,
         navigateToHome = myJogboDetailViewModel::navigateToHome
     )
 }
@@ -121,14 +119,13 @@ fun MyJogboDetailScreen(
     storeItems: EmptyUiState<PersistentList<Store>>,
     deleteDialogState: Boolean,
     shareDialogState: Boolean,
-    userInformation: UserInformationEntity,
+    userNickname: String,
     updateShareDialogState: () -> Unit,
     updateDeleteDialogState: () -> Unit,
     deleteJogboStore: (Long) -> Unit,
     selectedStoreId: Long,
     updateSelectedStoreId: (Long) -> Unit,
     navigateToStoreDetail: (Long) -> Unit,
-    userName: String,
     navigateToHome: () -> Unit,
 ) {
     if (shareDialogState) {
@@ -195,7 +192,7 @@ fun MyJogboDetailScreen(
         JogboFolder(
             title = jogboTitle,
             chips = jogboChips,
-            userName = userInformation.nickname,
+            userNickname = userNickname,
             shareJogbo = updateShareDialogState
         )
 

--- a/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
@@ -104,7 +104,7 @@ fun MyJogboDetailRoute(
             )
         },
         selectedStoreId = myJogboDetailState.selectedStoreId,
-        updateSelectedStoreId = { storeId -> myJogboDetailViewModel.updateSelectedStoreId(storeId) },
+        updateSelectedStoreId = myJogboDetailViewModel::updateSelectedStoreId,
         navigateToStoreDetail = myJogboDetailViewModel::navigateToStoreDetail,
         userName = myJogboDetailState.userInformation.nickname,
         navigateToHome = myJogboDetailViewModel::navigateToHome

--- a/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
@@ -76,11 +76,12 @@ fun MyJogboDetailRoute(
         myJogboDetailViewModel.getUserName()
     }
 
-    LaunchedEffect(myJogboDetailViewModel.mySideEffect, lifecycleOwner) {
-        myJogboDetailViewModel.mySideEffect.flowWithLifecycle(lifecycleOwner.lifecycle)
-            .collect { sideEffect ->
+    LaunchedEffect(myJogboDetailViewModel.mySideEffect,lifecycleOwner) {
+        myJogboDetailViewModel.mySideEffect.flowWithLifecycle(lifecycleOwner.lifecycle).collect { sideEffect ->
                 when (sideEffect) {
                     is MyJogboSideEffect.NavigateToDetail -> navigateToDetail(sideEffect.id)
+
+                    is MyJogboSideEffect.NavigateToHome -> navigateToHome()
                 }
             }
     }
@@ -106,7 +107,7 @@ fun MyJogboDetailRoute(
         updateSelectedStoreId = { storeId -> myJogboDetailViewModel.updateSelectedStoreId(storeId) },
         onClickStoreItem = { storeId -> myJogboDetailViewModel.onClickStoreItem(storeId) },
         userName = myJogboDetailState.userInformation.nickname,
-        navigateToHome = navigateToHome
+        navigateToHome = myJogboDetailViewModel::navigateToHome
     )
 }
 

--- a/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailViewModel.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailViewModel.kt
@@ -84,6 +84,12 @@ class MyJogboDetailViewModel @Inject constructor(
         }
     }
 
+    fun navigateToHome() {
+        viewModelScope.launch {
+            _mySideEffect.emit(MyJogboSideEffect.NavigateToHome)
+        }
+    }
+
     fun getUserName() {
         viewModelScope.launch {
             myRepository.getUserInformation()

--- a/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailViewModel.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailViewModel.kt
@@ -78,9 +78,9 @@ class MyJogboDetailViewModel @Inject constructor(
         )
     }
 
-    fun onClickStoreItem(storeId: Long) {
+    fun navigateToStoreDetail(storeId: Long) {
         viewModelScope.launch {
-
+            _mySideEffect.emit(MyJogboSideEffect.NavigateToDetail(storeId))
         }
     }
 

--- a/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboSideEffect.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboSideEffect.kt
@@ -2,4 +2,5 @@ package com.hankki.feature.my.myjogbodetail
 
 sealed class MyJogboSideEffect {
     data class NavigateToDetail(val id: Long) : MyJogboSideEffect()
+    data object NavigateToHome : MyJogboSideEffect()
 }

--- a/feature/my/src/main/java/com/hankki/feature/my/mystore/MyStoreRoute.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/mystore/MyStoreRoute.kt
@@ -73,8 +73,9 @@ fun MyStoreRoute(
         type = type,
         state = myStoreState.uiState,
         updateStoreSelected = myStoreViewModel::updateStoreSelected,
-        onClickItem = myStoreViewModel::onClickItem
-    )
+        onClickItem = myStoreViewModel::onClickItem,
+        navigateToStoreDetail = myStoreViewModel::navigateToStoreDetail,
+        )
 }
 
 @Composable
@@ -85,8 +86,9 @@ fun MyStoreScreen(
     state: EmptyUiState<PersistentList<MyStoreModel>>,
     modifier: Modifier = Modifier,
     updateStoreSelected: (Long, Boolean) -> Unit,
-    onClickItem: (Long) -> Unit = {}
-) {
+    onClickItem: (Long) -> Unit = {},
+    navigateToStoreDetail: (Long) -> Unit,
+    ) {
     Column(
         modifier = modifier
             .padding((paddingValues))
@@ -147,6 +149,9 @@ fun MyStoreScreen(
                                 editSelected = {
                                     updateStoreSelected(store.id, store.isLiked == true)
                                 },
+                                modifier =  Modifier.noRippleClickable{
+                                    navigateToStoreDetail(store.id)
+                                },
                                 onClickItem = {
                                     onClickItem(store.id)
                                 }
@@ -175,7 +180,8 @@ fun MyStoreScreenPreview() {
             navigateUp = {},
             type = "like",
             state = EmptyUiState.Empty,
-            updateStoreSelected = { _, _ -> }
+            updateStoreSelected = { _, _ -> },
+            navigateToStoreDetail = {}
         )
     }
 }

--- a/feature/my/src/main/java/com/hankki/feature/my/mystore/MyStoreRoute.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/mystore/MyStoreRoute.kt
@@ -73,9 +73,8 @@ fun MyStoreRoute(
         type = type,
         state = myStoreState.uiState,
         updateStoreSelected = myStoreViewModel::updateStoreSelected,
-        onClickItem = myStoreViewModel::onClickItem,
         navigateToStoreDetail = myStoreViewModel::navigateToStoreDetail,
-        )
+    )
 }
 
 @Composable
@@ -86,9 +85,8 @@ fun MyStoreScreen(
     state: EmptyUiState<PersistentList<MyStoreModel>>,
     modifier: Modifier = Modifier,
     updateStoreSelected: (Long, Boolean) -> Unit,
-    onClickItem: (Long) -> Unit = {},
     navigateToStoreDetail: (Long) -> Unit,
-    ) {
+) {
     Column(
         modifier = modifier
             .padding((paddingValues))
@@ -133,10 +131,7 @@ fun MyStoreScreen(
                 EmptyUiState.Loading -> {}
 
                 is EmptyUiState.Success -> {
-                    LazyColumn(
-                        modifier = Modifier
-                            .padding(start = 22.dp, end = 11.dp)
-                    ) {
+                    LazyColumn {
                         itemsIndexed(state.data) { index, store ->
                             StoreItem(
                                 imageUrl = store.imageURL,
@@ -149,16 +144,16 @@ fun MyStoreScreen(
                                 editSelected = {
                                     updateStoreSelected(store.id, store.isLiked == true)
                                 },
-                                modifier =  Modifier.noRippleClickable{
+                                modifier = Modifier.noRippleClickable {
                                     navigateToStoreDetail(store.id)
-                                },
-                                onClickItem = {
-                                    onClickItem(store.id)
                                 }
                             )
                             if (index != state.data.lastIndex) {
                                 HorizontalDivider(
-                                    modifier = Modifier.padding(vertical = 1.dp),
+                                    modifier = Modifier.padding(
+                                        vertical = 1.dp,
+                                        horizontal = 22.dp
+                                    ),
                                     thickness = 1.dp,
                                     color = Gray200
                                 )

--- a/feature/my/src/main/java/com/hankki/feature/my/mystore/MyStoreViewModel.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/mystore/MyStoreViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hankki.core.common.utill.EmptyUiState
 import com.hankki.domain.my.repository.MyRepository
+import com.hankki.feature.my.myjogbodetail.MyJogboSideEffect
 import com.hankki.feature.my.mystore.model.toMyStoreModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentList
@@ -119,7 +120,11 @@ class MyStoreViewModel @Inject constructor(
         }
     }
 
-
+    fun navigateToStoreDetail(storeId: Long) {
+        viewModelScope.launch {
+            _mySideEffect.emit(MyStoreSideEffect.NavigateToDetail(storeId))
+        }
+    }
 //    fun updateStoreSelected(id: Long, isLiked: Boolean) {
 //        viewModelScope.launch {
 //            if (isLiked) {

--- a/feature/my/src/main/java/com/hankki/feature/my/mystore/MyStoreViewModel.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/mystore/MyStoreViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hankki.core.common.utill.EmptyUiState
 import com.hankki.domain.my.repository.MyRepository
-import com.hankki.feature.my.myjogbodetail.MyJogboSideEffect
 import com.hankki.feature.my.mystore.model.toMyStoreModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentList
@@ -123,41 +122,6 @@ class MyStoreViewModel @Inject constructor(
     fun navigateToStoreDetail(storeId: Long) {
         viewModelScope.launch {
             _mySideEffect.emit(MyStoreSideEffect.NavigateToDetail(storeId))
-        }
-    }
-//    fun updateStoreSelected(id: Long, isLiked: Boolean) {
-//        viewModelScope.launch {
-//            if (isLiked) {
-//                myRepository.unLikeStore(id).onSuccess {
-//                    _myStoreState.value = _myStoreState.value.copy(
-//                        uiState = _myStoreState.value.uiState.map {
-//                            if (it.id == id) {
-//                                it.copy(isLiked = false)
-//                            } else {
-//                                it
-//                            }
-//                        }.toPersistentList()
-//                    )
-//                }
-//            } else {
-//                myRepository.likeStore(id).onSuccess {
-//                    _myStoreState.value = _myStoreState.value.copy(
-//                        uiState = _myStoreState.value.uiState.map {
-//                            if (it.id == id) {
-//                                it.copy(isLiked = true)
-//                            } else {
-//                                it
-//                            }
-//                        }.toPersistentList()
-//                    )
-//                }
-//            }
-//        }
-//    }
-
-    fun onClickItem(id: Long) {
-        viewModelScope.launch {
-            _mySideEffect.emit(MyStoreSideEffect.NavigateToDetail(id))
         }
     }
 }


### PR DESCRIPTION
- closed #151 

## *⛳️ Work Description*
- 나의 족보 상세-> 홈화면 이동 sideEffect로 변경했습니다
- 지난 PR에서 아이템 패딩을 줬기때문에 기존 화면 패딩을 삭제했습니다
- 족보에서 가게 클릭시 해당가게로 넘어가도록
- 제보한/좋아요한 식당에서 가게 클릭시 해당 가게로 넘어가도록

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<img src="https://github.com/user-attachments/assets/837ffc88-45a8-4ebd-bc35-d79353709af2" width=270 />


## *📢 To Reviewers*
- 
