### PR TITLE
[Fix #161] kakao sdk

### DIFF
--- a/data/home/build.gradle.kts
+++ b/data/home/build.gradle.kts
@@ -10,4 +10,6 @@ android {
 
 dependencies {
     implementation(projects.domain.home)
+    implementation(libs.androidx.monitor)
+    implementation(libs.androidx.junit.ktx)
 }

--- a/feature/login/src/main/java/com/hankki/feature/login/LoginRoute.kt
+++ b/feature/login/src/main/java/com/hankki/feature/login/LoginRoute.kt
@@ -1,5 +1,6 @@
 package com.hankki.feature.login
 
+import android.app.Activity
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,6 +14,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -31,6 +33,7 @@ fun LoginRoute(
 ) {
     val viewModel: LoginViewModel = hiltViewModel()
     val lifecycleOwner = LocalLifecycleOwner.current
+    val context = LocalContext.current
 
     LaunchedEffect(viewModel.loginSideEffects, lifecycleOwner) {
         viewModel.loginSideEffects
@@ -53,7 +56,7 @@ fun LoginRoute(
     }
 
     LoginScreen(
-        onLoginClick = { viewModel.startKakaoLogin() }
+        onLoginClick = { viewModel.startKakaoLogin(context as Activity) }
     )
 }
 

--- a/feature/login/src/main/java/com/hankki/feature/login/LoginRoute.kt
+++ b/feature/login/src/main/java/com/hankki/feature/login/LoginRoute.kt
@@ -1,6 +1,6 @@
 package com.hankki.feature.login
 
-import android.app.Activity
+import android.content.Context
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -24,6 +24,7 @@ import androidx.lifecycle.flowWithLifecycle
 import com.hankki.core.common.extension.noRippleClickable
 import com.hankki.core.designsystem.theme.HankkiTheme
 import com.hankki.core.designsystem.theme.White
+import com.kakao.sdk.user.UserApiClient
 import kotlinx.coroutines.flow.collectLatest
 
 @Composable
@@ -51,14 +52,27 @@ fun LoginRoute(
                     is LoginSideEffect.LoginError -> {
                         //LoginError 필요시 추가 동작
                     }
+
+                    is LoginSideEffect.StartKakaoTalkLogin -> {
+                        startKakaoTalkLogin(context, viewModel)
+                    }
+
+                    is LoginSideEffect.StartKakaoWebLogin -> {
+                        startKakaoWebLogin(context, viewModel)
+                    }
                 }
             }
     }
 
     LoginScreen(
-        onLoginClick = { viewModel.startKakaoLogin(context as Activity) }
+        onLoginClick = {
+            viewModel.startKakaoLogin(
+                isKakaoTalkAvailable = UserApiClient.instance.isKakaoTalkLoginAvailable(context)
+            )
+        }
     )
 }
+
 
 @Composable
 fun LoginScreen(
@@ -100,5 +114,17 @@ fun LoginScreen(
                 .padding(bottom = 24.dp)
                 .navigationBarsPadding()
         )
+    }
+}
+
+private fun startKakaoTalkLogin(context: Context, viewModel: LoginViewModel) {
+    UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
+        viewModel.handleLoginResult(token, error)
+    }
+}
+
+private fun startKakaoWebLogin(context: Context, viewModel: LoginViewModel) {
+    UserApiClient.instance.loginWithKakaoAccount(context) { token, error ->
+        viewModel.handleLoginResult(token, error)
     }
 }

--- a/feature/login/src/main/java/com/hankki/feature/login/LoginRoute.kt
+++ b/feature/login/src/main/java/com/hankki/feature/login/LoginRoute.kt
@@ -24,6 +24,7 @@ import androidx.lifecycle.flowWithLifecycle
 import com.hankki.core.common.extension.noRippleClickable
 import com.hankki.core.designsystem.theme.HankkiTheme
 import com.hankki.core.designsystem.theme.White
+import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.user.UserApiClient
 import kotlinx.coroutines.flow.collectLatest
 
@@ -54,11 +55,15 @@ fun LoginRoute(
                     }
 
                     is LoginSideEffect.StartKakaoTalkLogin -> {
-                        startKakaoTalkLogin(context, viewModel)
+                        startKakaoTalkLogin(context) { token, error ->
+                            viewModel.handleLoginResult(token, error)
+                        }
                     }
 
                     is LoginSideEffect.StartKakaoWebLogin -> {
-                        startKakaoWebLogin(context, viewModel)
+                        startKakaoWebLogin(context) { token, error ->
+                            viewModel.handleLoginResult(token, error)
+                        }
                     }
                 }
             }
@@ -117,14 +122,20 @@ fun LoginScreen(
     }
 }
 
-private fun startKakaoTalkLogin(context: Context, viewModel: LoginViewModel) {
+private fun startKakaoTalkLogin(
+    context: Context,
+    handleLogin: (OAuthToken?, Throwable?) -> Unit,
+) {
     UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
-        viewModel.handleLoginResult(token, error)
+        handleLogin(token, error)
     }
 }
 
-private fun startKakaoWebLogin(context: Context, viewModel: LoginViewModel) {
+private fun startKakaoWebLogin(
+    context: Context,
+    handleLogin: (OAuthToken?, Throwable?) -> Unit,
+) {
     UserApiClient.instance.loginWithKakaoAccount(context) { token, error ->
-        viewModel.handleLoginResult(token, error)
+        handleLogin(token, error)
     }
 }

--- a/feature/login/src/main/java/com/hankki/feature/login/LoginSideEffect.kt
+++ b/feature/login/src/main/java/com/hankki/feature/login/LoginSideEffect.kt
@@ -3,4 +3,6 @@ package com.hankki.feature.login
 sealed class LoginSideEffect {
     data class LoginSuccess(val accessToken: String, val isRegistered: Boolean) : LoginSideEffect()
     data class LoginError(val errorMessage: String) : LoginSideEffect()
+    data object StartKakaoTalkLogin : LoginSideEffect()
+    data object StartKakaoWebLogin : LoginSideEffect()
 }

--- a/feature/login/src/main/java/com/hankki/feature/login/LoginViewModel.kt
+++ b/feature/login/src/main/java/com/hankki/feature/login/LoginViewModel.kt
@@ -1,5 +1,6 @@
 package com.hankki.feature.login
 
+import android.app.Activity
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -11,7 +12,6 @@ import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
 import com.kakao.sdk.user.UserApiClient
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
@@ -20,45 +20,45 @@ import javax.inject.Inject
 @HiltViewModel
 class LoginViewModel @Inject constructor(
     private val loginRepository: LoginRepository,
-    private val tokenRepository: TokenRepository,
-    @ApplicationContext private val context: Context
+    private val tokenRepository: TokenRepository
 ) : ViewModel() {
 
     private val _loginSideEffects = MutableSharedFlow<LoginSideEffect>()
     val loginSideEffects: SharedFlow<LoginSideEffect>
         get() = _loginSideEffects
 
-    fun startKakaoLogin() {
+    private val callback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
+        if (error != null) {
+            if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
+                handleLoginError("로그인 취소")
+            } else {
+                handleLoginError("카카오계정으로 로그인 실패")
+            }
+        } else if (token != null) {
+            sendTokenToServer(token.accessToken)
+        }
+    }
+
+    fun startKakaoLogin(context: Context) {
         if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
-            UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
-                handleLoginResult(token, error)
+            UserApiClient.instance.loginWithKakaoTalk(context as Activity) { token, error ->
+                if (error != null) {
+                    if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
+                        handleLoginError("로그인 취소")
+                        return@loginWithKakaoTalk
+                    }
+                    startKakaoWebLogin(context)
+                } else if (token != null) {
+                    sendTokenToServer(token.accessToken)
+                }
             }
         } else {
-            UserApiClient.instance.loginWithKakaoAccount(context) { token, error ->
-                handleLoginResult(token, error)
-            }
+            startKakaoWebLogin(context)
         }
     }
 
-    private fun handleLoginResult(token: OAuthToken?, error: Throwable?) {
-        viewModelScope.launch {
-            if (error != null) {
-                if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
-                    handleLoginError("로그인 취소")
-                } else {
-                    handleLoginError("카카오계정으로 로그인 실패: ${error.localizedMessage}")
-                    startKakaoWebLogin()
-                }
-            } else if (token != null) {
-                sendTokenToServer(token.accessToken)
-            }
-        }
-    }
-
-    private fun startKakaoWebLogin() {
-        UserApiClient.instance.loginWithKakaoAccount(context) { token, error ->
-            handleLoginResult(token, error)
-        }
+    private fun startKakaoWebLogin(context: Context) {
+        UserApiClient.instance.loginWithKakaoAccount(context, callback = callback)
     }
 
     private fun sendTokenToServer(
@@ -69,17 +69,17 @@ class LoginViewModel @Inject constructor(
             loginRepository.postLogin(accessToken, LoginRequestEntity(platform))
                 .onSuccess { response ->
                     tokenRepository.setTokens(response.accessToken, response.refreshToken)
-                    _loginSideEffects.emit(LoginSideEffect.LoginSuccess(response.accessToken, response.isRegistered))
+                    _loginSideEffects.emit(
+                        LoginSideEffect.LoginSuccess(
+                            response.accessToken,
+                            response.isRegistered
+                        )
+                    )
                 }.onFailure { throwable ->
                     val errorMessage = throwable.localizedMessage ?: "Unknown error"
                     handleLoginError(errorMessage)
                 }
         }
-    }
-
-
-    fun clearToken() {
-        tokenRepository.clearInfo()
     }
 
     private fun handleLoginError(errorMessage: String) {


### PR DESCRIPTION
- closed #161

## *⛳️ Work Description*
- 카카오 로그인 웹, 앱

## *📸 Screenshot*
- 기존과 동일합니다.

## *📢 To Reviewers*
ㅎㅎ..
로그인 문제를 해결하려면 어쩔 수 없이 Context가 필요하더라구요.
근데 그냥 Context를 사용했을 때도 로그인이 잘 안되어서 에러를 찍어보니
<img src="https://github.com/user-attachments/assets/3e5e3799-593f-4077-a86b-a12f5e9e6c1c" width=800 />
위에 사진처럼 startActivity()를 호출할 때 Activity가 아닌 Context를 사용해서 나타는 문제라고 하여
기존에 사용했던 ApplicationContext는 애플리케이션의 전체 수명 동안 지속되기도 하고, 
특정 UI와 관련된 Activity의 생명 주기에 연결되지 않아 UI 관련한 작업 처리에 적합하지 않다고 판단했습니다.
따라서 Context를 Activity로 캐스팅하여 구현하였습니다.



