### PR TITLE
[Fix/#223] 2nd my qa

### DIFF
--- a/core/designsystem/src/main/java/com/hankki/core/designsystem/component/textfield/HankkiCountTextField.kt
+++ b/core/designsystem/src/main/java/com/hankki/core/designsystem/component/textfield/HankkiCountTextField.kt
@@ -22,11 +22,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
@@ -53,7 +55,7 @@ fun HankkiCountTextField(
     placeholder: String,
     trailingIcon: Boolean,
     onValueChanged: (String) -> Unit,
-    resetTitle : Boolean,
+    resetTitle: Boolean,
     modifier: Modifier = Modifier
 ) {
     var isFocused by remember { mutableStateOf(false) }
@@ -120,7 +122,8 @@ fun HankkiCountTextField(
                         val cursorPosition = if (modifiedValue.isEmpty()) {
                             1
                         } else {
-                            newValue.selection.start.coerceAtLeast(1).coerceAtMost(modifiedValue.length)
+                            newValue.selection.start.coerceAtLeast(1)
+                                .coerceAtMost(modifiedValue.length)
                         }
 
                         if (newValue.text.contains("# ") || newValue.text.contains(" #")) {
@@ -178,6 +181,7 @@ fun HankkiCountInnerTextField(
 ) {
     val focusRequester = remember { FocusRequester() }
     val focusManager = LocalFocusManager.current
+    val keyboardController = LocalSoftwareKeyboardController.current
 
     BasicTextField(
         value = value,
@@ -195,10 +199,14 @@ fun HankkiCountInnerTextField(
         keyboardOptions = keyboardOptions,
         keyboardActions = KeyboardActions(
             onDone = {
-                focusManager.clearFocus()
+                if (!focusManager.moveFocus(FocusDirection.Down)) {
+                    focusManager.clearFocus()
+                }
             },
             onSearch = {
-                focusManager.clearFocus()
+                if (!focusManager.moveFocus(FocusDirection.Down)) {
+                    focusManager.clearFocus()
+                }
             }
         ),
         textStyle = HankkiTheme.typography.body1.copy(color = textColor),

--- a/feature/main/src/main/java/com/hankki/feature/main/MainNavigator.kt
+++ b/feature/main/src/main/java/com/hankki/feature/main/MainNavigator.kt
@@ -143,7 +143,7 @@ internal class MainNavigator(
     }
 
     fun navigateToMyJogboDetail(favoriteId: Long) {
-        navController.navigateMyJogboDetail(favoriteId = favoriteId)
+        navController.navigateMyJogboDetail(favoriteId = favoriteId, navOptions {  })
     }
 
     fun navigateToNewJogbo() {

--- a/feature/main/src/main/java/com/hankki/feature/main/MainNavigator.kt
+++ b/feature/main/src/main/java/com/hankki/feature/main/MainNavigator.kt
@@ -15,6 +15,7 @@ import com.hankki.feature.home.navigation.navigateHome
 import com.hankki.feature.login.navigation.Login
 import com.hankki.feature.login.navigation.navigateOnboarding
 import com.hankki.feature.main.splash.navigation.Splash
+import com.hankki.feature.my.navigation.MyJogboDetail
 import com.hankki.feature.my.navigation.navigateMy
 import com.hankki.feature.my.navigation.navigateMyJogbo
 import com.hankki.feature.my.navigation.navigateMyJogboDetail
@@ -143,7 +144,12 @@ internal class MainNavigator(
     }
 
     fun navigateToMyJogboDetail(favoriteId: Long) {
-        navController.navigateMyJogboDetail(favoriteId = favoriteId, navOptions {  })
+        navController.navigateMyJogboDetail(favoriteId = favoriteId, navOptions = navOptions {
+            popUpTo<MyJogboDetail> {
+                saveState = true
+            }
+            restoreState = true
+        })
     }
 
     fun navigateToNewJogbo() {

--- a/feature/main/src/main/java/com/hankki/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/hankki/feature/main/MainScreen.kt
@@ -287,7 +287,8 @@ internal fun MainScreen(
                     storeDetailNavGraph(
                         navigateUp = navigator::navigateUpIfNotHome,
                         navigateToAddNewJogbo = navigator::navigateToNewJogbo,
-                        onShowSnackBar = onShowTextSnackBarWithButton
+                        onShowSnackBar = onShowTextSnackBarWithButton,
+                        onShowTextSnackBar = onShowErrorSnackBar
                     )
                 }
 

--- a/feature/my/src/main/java/com/hankki/feature/my/component/StoreItem.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/component/StoreItem.kt
@@ -56,7 +56,6 @@ fun StoreItem(
         modifier = modifier
             .fillMaxWidth()
             .wrapContentHeight()
-            .clip(RoundedCornerShape(10.dp))
             .background(White)
             .padding(vertical = 16.dp, horizontal = 22.dp),
         verticalAlignment = Alignment.CenterVertically,

--- a/feature/my/src/main/java/com/hankki/feature/my/component/StoreItem.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/component/StoreItem.kt
@@ -50,8 +50,6 @@ fun StoreItem(
     modifier: Modifier = Modifier,
     editSelected: () -> Unit = {},
 ) {
-    val formattedPrice = price.formatPrice()
-
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -105,7 +103,7 @@ fun StoreItem(
                 Spacer(modifier = Modifier.width(3.dp))
 
                 Text(
-                    text = "${formattedPrice}원",
+                    text = "${price.formatPrice()}원",
                     style = HankkiTheme.typography.button1,
                     color = Gray500
                 )

--- a/feature/my/src/main/java/com/hankki/feature/my/myjogbo/MyJogboRoute.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/myjogbo/MyJogboRoute.kt
@@ -69,7 +69,8 @@ fun MyJogboRoute(
         resetEditModeState = myJogboViewModel::resetEditModeState,
         deleteDialogState = state.dialogState,
         updateDeleteDialogState = myJogboViewModel::updateDeleteDialogState,
-        deleteSelectedJogbo = myJogboViewModel::deleteSelectedJogbo
+        deleteSelectedJogbo = myJogboViewModel::deleteSelectedJogbo,
+        buttonEnabledState = state.buttonEnabled
     )
 
     BackOnPressed(
@@ -85,13 +86,14 @@ fun MyJogboScreen(
     navigateToJogboDetail: (Long) -> Unit,
     navigateToNewJogbo: () -> Unit,
     state: UiState<PersistentList<MyJogboModel>>,
-    editModeState: Boolean = false,
+    editModeState: Boolean,
     updateEditModeState: () -> Unit,
     updateJogboSelectedState: (Int, Boolean) -> Unit,
     resetEditModeState: () -> Unit,
     deleteDialogState: Boolean,
     updateDeleteDialogState: (Boolean) -> Unit,
     deleteSelectedJogbo: () -> Unit,
+    buttonEnabledState: Boolean
 ) {
     if (deleteDialogState) {
         DoubleButtonDialog(
@@ -99,7 +101,7 @@ fun MyJogboScreen(
             negativeButtonTitle = stringResource(id = R.string.close),
             positiveButtonTitle = stringResource(id = R.string.do_delete),
             onNegativeButtonClicked = { updateDeleteDialogState(false) },
-            onPositiveButtonClicked = deleteSelectedJogbo
+            onPositiveButtonClicked = { if (buttonEnabledState) deleteSelectedJogbo() }
         )
     }
 
@@ -226,7 +228,9 @@ fun MyJogboScreenPreview() {
             resetEditModeState = {},
             deleteDialogState = false,
             updateDeleteDialogState = {},
-            deleteSelectedJogbo = {}
+            deleteSelectedJogbo = {},
+            buttonEnabledState = false,
+            editModeState = false
         )
     }
 }

--- a/feature/my/src/main/java/com/hankki/feature/my/myjogbo/MyJogboRoute.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/myjogbo/MyJogboRoute.kt
@@ -141,12 +141,15 @@ fun MyJogboScreen(
                         .padding(vertical = 12.dp, horizontal = 14.dp)
                         .padding(end = 9.dp)
                         .run {
-                            if (editModeState && isSelectedJogboExists) noRippleClickable {
-                                updateDeleteDialogState(
-                                    true
-                                )
+                            if (editModeState && isSelectedJogboExists) {
+                                noRippleClickable {
+                                    updateDeleteDialogState(true)
+                                }
+                            } else if (!editModeState) {
+                                noRippleClickable(updateEditModeState)
+                            } else {
+                                this
                             }
-                            else noRippleClickable(updateEditModeState)
                         }
                 )
             }

--- a/feature/my/src/main/java/com/hankki/feature/my/myjogbo/MyJogboState.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/myjogbo/MyJogboState.kt
@@ -8,4 +8,5 @@ data class MyJogboState(
     val editModeState: Boolean = false,
     val uiState: UiState<PersistentList<MyJogboModel>> = UiState.Loading,
     var dialogState: Boolean = false,
+    var buttonEnabled : Boolean = false
 )

--- a/feature/my/src/main/java/com/hankki/feature/my/myjogbo/MyJogboViewModel.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/myjogbo/MyJogboViewModel.kt
@@ -80,7 +80,8 @@ class MyJogboViewModel @Inject constructor(
 
     fun updateDeleteDialogState(state: Boolean) {
         _myJogboState.value = _myJogboState.value.copy(
-            dialogState = state
+            dialogState = state,
+            buttonEnabled = true
         )
     }
 
@@ -88,12 +89,11 @@ class MyJogboViewModel @Inject constructor(
         val currentState = _myJogboState.value.uiState
         if (currentState is UiState.Success) {
             val jogboItems = currentState.data
-            val deleteList = jogboItems.filter {
-                it.jogboSelected
-            }.map {
-                it.jogboId
-            }
+            val deleteList = jogboItems.filter { it.jogboSelected }.map { it.jogboId }
             viewModelScope.launch {
+                _myJogboState.value = _myJogboState.value.copy(
+                    buttonEnabled = false
+                )
                 myRepository.deleteJogboStores(deleteList)
                     .onSuccess {
                         _myJogboState.value = _myJogboState.value.copy(

--- a/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -121,6 +122,7 @@ fun MyJogboDetailScreen(
     val height by rememberSaveable {
         mutableDoubleStateOf(configuration.screenHeightDp * 0.09)
     }
+    val scrollState = rememberLazyListState()
 
     if (shareDialogState) {
         SingleButtonDialog(
@@ -176,7 +178,8 @@ fun MyJogboDetailScreen(
             modifier = Modifier
                 .navigationBarsPadding()
                 .fillMaxSize(),
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
+            state = scrollState
         ) {
             when (state) {
                 is EmptyUiState.Loading -> {

--- a/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
@@ -118,7 +118,7 @@ fun MyJogboDetailScreen(
 ) {
     val configuration = LocalConfiguration.current
     val height by rememberSaveable {
-        mutableDoubleStateOf(configuration.screenHeightDp * 0.12)
+        mutableDoubleStateOf(configuration.screenHeightDp * 0.09)
     }
 
     if (shareDialogState) {

--- a/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -20,9 +19,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableDoubleStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -114,6 +116,11 @@ fun MyJogboDetailScreen(
     navigateToStoreDetail: (Long) -> Unit,
     navigateToHome: () -> Unit,
 ) {
+    val configuration = LocalConfiguration.current
+    val height by rememberSaveable {
+        mutableDoubleStateOf(configuration.screenHeightDp * 0.12)
+    }
+
     if (shareDialogState) {
         SingleButtonDialog(
             title = stringResource(R.string.please_wait),
@@ -135,102 +142,100 @@ fun MyJogboDetailScreen(
         )
     }
 
-    Column(
+    LazyColumn(
         modifier = Modifier
             .navigationBarsPadding()
             .fillMaxSize()
-            .background(Red500),
+            .background(White),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Spacer(
-            modifier = Modifier
-                .statusBarsPadding()
-                .background(Red500)
-        )
-
-        HankkiTopBar(
-            modifier = Modifier.background(Red500),
-            leadingIcon = {
-                Icon(
-                    painter = painterResource(id = com.hankki.core.designsystem.R.drawable.ic_arrow_left),
-                    contentDescription = "Back",
-                    modifier = Modifier
-                        .padding(start = 6.dp)
-                        .size(44.dp)
-                        .noRippleClickable(onClick = navigateUp),
-                    tint = Color.Unspecified
-                )
-            },
-            content = {
-                Text(
-                    text = stringResource(R.string.my_jogbo),
-                    style = HankkiTheme.typography.sub3,
-                    color = Gray900
-                )
-            }
-        )
+        item {
+            HankkiTopBar(
+                modifier = Modifier
+                    .background(Red500)
+                    .statusBarsPadding(),
+                leadingIcon = {
+                    Icon(
+                        painter = painterResource(id = com.hankki.core.designsystem.R.drawable.ic_arrow_left),
+                        contentDescription = "Back",
+                        modifier = Modifier
+                            .padding(start = 6.dp)
+                            .size(44.dp)
+                            .noRippleClickable(onClick = navigateUp),
+                        tint = Color.Unspecified
+                    )
+                },
+                content = {
+                    Text(
+                        text = stringResource(R.string.my_jogbo),
+                        style = HankkiTheme.typography.sub3,
+                        color = Gray900
+                    )
+                }
+            )
+        }
 
         when (state) {
             is EmptyUiState.Loading -> {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(White)
-                ) {
-                    HankkiLoadingScreen(modifier = Modifier.align(Alignment.Center))
+                item {
+                    Box(
+                        modifier = Modifier
+                            .fillParentMaxSize()
+                    ) {
+                        HankkiLoadingScreen(modifier = Modifier.align(Alignment.Center))
+                    }
                 }
             }
 
             is EmptyUiState.Success -> {
-                JogboFolder(
-                    title = jogboTitle,
-                    chips = jogboChips,
-                    userNickname = userNickname,
-                    shareJogboDialogState = updateShareDialogState
-                )
+                item {
+                    JogboFolder(
+                        title = jogboTitle,
+                        chips = jogboChips,
+                        userNickname = userNickname,
+                        shareJogboDialogState = updateShareDialogState
+                    )
+                }
 
-                LazyColumn(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(White),
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    item {
-                        Spacer(modifier = Modifier.height(4.dp))
-                    }
+                item {
+                    Spacer(modifier = Modifier.height(4.dp))
+                }
 
-                    items(state.data) { store ->
-                        StoreItem(
-                            imageUrl = store.imageUrl,
-                            category = store.category,
-                            name = store.name,
-                            price = store.lowestPrice.toString(),
-                            heartCount = store.heartCount,
-                            isIconUsed = false,
-                            isIconSelected = false,
-                            modifier = Modifier.combinedClickable(
-                                onClick = { navigateToStoreDetail(store.id) },
-                                onLongClick = {
-                                    updateSelectedStoreId(store.id)
-                                    updateDeleteDialogState()
-                                }
-                            )
+                items(state.data) { store ->
+                    StoreItem(
+                        imageUrl = store.imageUrl,
+                        category = store.category,
+                        name = store.name,
+                        price = store.lowestPrice.toString(),
+                        heartCount = store.heartCount,
+                        isIconUsed = false,
+                        isIconSelected = false,
+                        modifier = Modifier.combinedClickable(
+                            onClick = { navigateToStoreDetail(store.id) },
+                            onLongClick = {
+                                updateSelectedStoreId(store.id)
+                                updateDeleteDialogState()
+                            }
                         )
-                        if (state.data.indexOf(store) != state.data.lastIndex) {
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = 1.dp, horizontal = 22.dp),
-                                thickness = 1.dp,
-                                color = Gray200
-                            )
-                        }
+                    )
+                    if (state.data.indexOf(store) != state.data.lastIndex) {
+                        HorizontalDivider(
+                            modifier = Modifier.padding(vertical = 1.dp, horizontal = 22.dp),
+                            thickness = 1.dp,
+                            color = Gray200
+                        )
                     }
+                }
 
-                    item {
-                        Spacer(modifier = Modifier.height(20.dp))
-
+                item {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(top = 20.dp, bottom = 30.dp),
+                        contentAlignment = Alignment.TopCenter
+                    ) {
                         MoveToHomeButton(
                             modifier = Modifier
-                                .padding(bottom = 30.dp)
                                 .noRippleClickable(navigateToHome),
                         )
                     }
@@ -238,24 +243,28 @@ fun MyJogboDetailScreen(
             }
 
             is EmptyUiState.Empty -> {
-                JogboFolder(
-                    title = jogboTitle,
-                    chips = jogboChips,
-                    userNickname = userNickname,
-                    shareJogboDialogState = updateShareDialogState
-                )
+                item {
+                    JogboFolder(
+                        title = jogboTitle,
+                        chips = jogboChips,
+                        userNickname = userNickname,
+                        shareJogboDialogState = updateShareDialogState
+                    )
 
-                EmptyViewWithButton(
-                    text = stringResource(R.string.my_jogbo) +
-                            stringResource(R.string.add_store_to_jogbo),
-                    content = {
-                        MoveToHomeButton(
-                            modifier = Modifier
-                                .padding(top = 20.dp)
-                                .noRippleClickable(navigateToHome),
-                        )
-                    }
-                )
+                    Spacer(modifier = Modifier.height((height).dp))
+
+                    EmptyViewWithButton(
+                        text = stringResource(R.string.my_jogbo) +
+                                stringResource(R.string.add_store_to_jogbo),
+                        content = {
+                            MoveToHomeButton(
+                                modifier = Modifier
+                                    .padding(top = 20.dp)
+                                    .noRippleClickable(navigateToHome),
+                            )
+                        }
+                    )
+                }
             }
 
             is EmptyUiState.Failure -> {}

--- a/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -142,132 +143,135 @@ fun MyJogboDetailScreen(
         )
     }
 
-    LazyColumn(
+    Column(
         modifier = Modifier
-            .navigationBarsPadding()
             .fillMaxSize()
-            .background(White),
-        horizontalAlignment = Alignment.CenterHorizontally
+            .background(White)
     ) {
-        item {
-            HankkiTopBar(
-                modifier = Modifier
-                    .background(Red500)
-                    .statusBarsPadding(),
-                leadingIcon = {
-                    Icon(
-                        painter = painterResource(id = com.hankki.core.designsystem.R.drawable.ic_arrow_left),
-                        contentDescription = "Back",
-                        modifier = Modifier
-                            .padding(start = 6.dp)
-                            .size(44.dp)
-                            .noRippleClickable(onClick = navigateUp),
-                        tint = Color.Unspecified
-                    )
-                },
-                content = {
-                    Text(
-                        text = stringResource(R.string.my_jogbo),
-                        style = HankkiTheme.typography.sub3,
-                        color = Gray900
-                    )
-                }
-            )
-        }
-
-        when (state) {
-            is EmptyUiState.Loading -> {
-                item {
-                    Box(
-                        modifier = Modifier
-                            .fillParentMaxSize()
-                    ) {
-                        HankkiLoadingScreen(modifier = Modifier.align(Alignment.Center))
-                    }
-                }
+        HankkiTopBar(
+            modifier = Modifier
+                .background(Red500)
+                .statusBarsPadding(),
+            leadingIcon = {
+                Icon(
+                    painter = painterResource(id = com.hankki.core.designsystem.R.drawable.ic_arrow_left),
+                    contentDescription = "Back",
+                    modifier = Modifier
+                        .padding(start = 6.dp)
+                        .size(44.dp)
+                        .noRippleClickable(onClick = navigateUp),
+                    tint = Color.Unspecified
+                )
+            },
+            content = {
+                Text(
+                    text = stringResource(R.string.my_jogbo),
+                    style = HankkiTheme.typography.sub3,
+                    color = Gray900
+                )
             }
+        )
 
-            is EmptyUiState.Success -> {
-                item {
-                    JogboFolder(
-                        title = jogboTitle,
-                        chips = jogboChips,
-                        userNickname = userNickname,
-                        shareJogboDialogState = updateShareDialogState
-                    )
-                }
-
-                item {
-                    Spacer(modifier = Modifier.height(4.dp))
-                }
-
-                items(state.data) { store ->
-                    StoreItem(
-                        imageUrl = store.imageUrl,
-                        category = store.category,
-                        name = store.name,
-                        price = store.lowestPrice.toString(),
-                        heartCount = store.heartCount,
-                        isIconUsed = false,
-                        isIconSelected = false,
-                        modifier = Modifier.combinedClickable(
-                            onClick = { navigateToStoreDetail(store.id) },
-                            onLongClick = {
-                                updateSelectedStoreId(store.id)
-                                updateDeleteDialogState()
-                            }
-                        )
-                    )
-                    if (state.data.indexOf(store) != state.data.lastIndex) {
-                        HorizontalDivider(
-                            modifier = Modifier.padding(vertical = 1.dp, horizontal = 22.dp),
-                            thickness = 1.dp,
-                            color = Gray200
-                        )
-                    }
-                }
-
-                item {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(top = 20.dp, bottom = 30.dp),
-                        contentAlignment = Alignment.TopCenter
-                    ) {
-                        MoveToHomeButton(
+        LazyColumn(
+            modifier = Modifier
+                .navigationBarsPadding()
+                .fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            when (state) {
+                is EmptyUiState.Loading -> {
+                    item {
+                        Box(
                             modifier = Modifier
-                                .noRippleClickable(navigateToHome),
-                        )
+                                .fillParentMaxSize()
+                        ) {
+                            HankkiLoadingScreen(modifier = Modifier.align(Alignment.Center))
+                        }
                     }
                 }
-            }
 
-            is EmptyUiState.Empty -> {
-                item {
-                    JogboFolder(
-                        title = jogboTitle,
-                        chips = jogboChips,
-                        userNickname = userNickname,
-                        shareJogboDialogState = updateShareDialogState
-                    )
+                is EmptyUiState.Success -> {
+                    item {
+                        JogboFolder(
+                            title = jogboTitle,
+                            chips = jogboChips,
+                            userNickname = userNickname,
+                            shareJogboDialogState = updateShareDialogState
+                        )
+                    }
 
-                    Spacer(modifier = Modifier.height((height).dp))
+                    item {
+                        Spacer(modifier = Modifier.height(4.dp))
+                    }
 
-                    EmptyViewWithButton(
-                        text = stringResource(R.string.my_jogbo) +
-                                stringResource(R.string.add_store_to_jogbo),
-                        content = {
+                    items(state.data) { store ->
+                        StoreItem(
+                            imageUrl = store.imageUrl,
+                            category = store.category,
+                            name = store.name,
+                            price = store.lowestPrice.toString(),
+                            heartCount = store.heartCount,
+                            isIconUsed = false,
+                            isIconSelected = false,
+                            modifier = Modifier.combinedClickable(
+                                onClick = { navigateToStoreDetail(store.id) },
+                                onLongClick = {
+                                    updateSelectedStoreId(store.id)
+                                    updateDeleteDialogState()
+                                }
+                            )
+                        )
+                        if (state.data.indexOf(store) != state.data.lastIndex) {
+                            HorizontalDivider(
+                                modifier = Modifier.padding(vertical = 1.dp, horizontal = 22.dp),
+                                thickness = 1.dp,
+                                color = Gray200
+                            )
+                        }
+                    }
+
+                    item {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(top = 20.dp, bottom = 30.dp),
+                            contentAlignment = Alignment.TopCenter
+                        ) {
                             MoveToHomeButton(
                                 modifier = Modifier
-                                    .padding(top = 20.dp)
                                     .noRippleClickable(navigateToHome),
                             )
                         }
-                    )
+                    }
                 }
-            }
 
-            is EmptyUiState.Failure -> {}
+                is EmptyUiState.Empty -> {
+                    item {
+                        JogboFolder(
+                            title = jogboTitle,
+                            chips = jogboChips,
+                            userNickname = userNickname,
+                            shareJogboDialogState = updateShareDialogState
+                        )
+
+                        Spacer(modifier = Modifier.height((height).dp))
+
+                        EmptyViewWithButton(
+                            text = stringResource(R.string.my_jogbo) +
+                                    stringResource(R.string.add_store_to_jogbo),
+                            content = {
+                                MoveToHomeButton(
+                                    modifier = Modifier
+                                        .padding(top = 20.dp)
+                                        .noRippleClickable(navigateToHome),
+                                )
+                            }
+                        )
+                    }
+                }
+
+                is EmptyUiState.Failure -> {}
+            }
         }
     }
 }

--- a/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailViewModel.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailViewModel.kt
@@ -30,9 +30,6 @@ class MyJogboDetailViewModel @Inject constructor(
         get() = _mySideEffect.asSharedFlow()
 
     fun getJogboDetail(favoriteId: Long) {
-        _myJogboDetailState.value = _myJogboDetailState.value.copy(
-            uiState = EmptyUiState.Loading
-        )
         viewModelScope.launch {
             myRepository.getJogboDetail(favoriteId)
                 .onSuccess { jogbo ->

--- a/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/component/MoveToHomeButton.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/component/MoveToHomeButton.kt
@@ -30,7 +30,6 @@ fun MoveToHomeButton(
     Row(
         modifier = modifier
             .clip(RoundedCornerShape(14.dp))
-            .wrapContentSize()
             .background(Gray100)
             .padding(vertical = 10.dp)
             .padding(start = 12.dp, end = 15.dp),

--- a/feature/my/src/main/java/com/hankki/feature/my/navigation/MyNavigation.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/navigation/MyNavigation.kt
@@ -27,8 +27,8 @@ fun NavController.navigateMyStore(type: String) {
     navigate(MyStore(type))
 }
 
-fun NavController.navigateMyJogboDetail(favoriteId: Long) {
-    navigate(MyJogboDetail(favoriteId = favoriteId))
+fun NavController.navigateMyJogboDetail(favoriteId: Long,navOptions: NavOptions) {
+    navigate(MyJogboDetail(favoriteId = favoriteId),navOptions)
 }
 
 fun NavController.navigateNewJogbo() {
@@ -62,7 +62,7 @@ fun NavGraphBuilder.myNavGraph(
     composable<MyJogboDetail> { backStackEntry ->
         val jogbo = backStackEntry.toRoute<MyJogboDetail>()
         MyJogboDetailRoute(
-            jogbo.favoriteId,
+            favoriteId = jogbo.favoriteId,
             navigateToDetail = navigateToStoreDetail,
             navigateUp = navigateUp,
             navigateToHome = navigateToHome
@@ -86,7 +86,7 @@ data class MyStore(
 
 @Serializable
 data class MyJogboDetail(
-    val favoriteId: Long,
+    val favoriteId: Long
 ) : Route
 
 @Serializable

--- a/feature/my/src/main/java/com/hankki/feature/my/newjogbo/NewJogboRoute.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/newjogbo/NewJogboRoute.kt
@@ -65,7 +65,7 @@ fun NewJogboRoute(
         onTitleChange = newJogboViewModel::setTitle,
         tags = state.tags,
         onTagsChange = newJogboViewModel::setTags,
-        buttonEnabled = state.isButtonEnabled,
+        buttonEnabledState = state.buttonEnabled,
         editTagsLength = newJogboViewModel::editTagsLength,
         createNewJogbo = newJogboViewModel::createNewJogbo,
         errorDialogState = state.errorDialogState,
@@ -81,7 +81,7 @@ fun NewJogboScreen(
     tags: String,
     onTagsChange: (String) -> Unit,
     editTagsLength: (String) -> Int,
-    buttonEnabled: Boolean,
+    buttonEnabledState: Boolean,
     createNewJogbo: () -> Unit,
     errorDialogState: Boolean,
     updateErrorDialogState: () -> Unit,
@@ -160,7 +160,7 @@ fun NewJogboScreen(
             HankkiMediumButton(
                 text = stringResource(R.string.make_jogbo),
                 onClick = createNewJogbo,
-                enabled = buttonEnabled,
+                enabled = buttonEnabledState,
                 textStyle = HankkiTheme.typography.sub3,
             )
         }
@@ -182,7 +182,7 @@ fun NewJogboScreenPreview() {
             tags = "",
             onTagsChange = {},
             editTagsLength = dummyEditTagsLength,
-            buttonEnabled = false,
+            buttonEnabledState = false,
             createNewJogbo = {},
             errorDialogState = false,
             updateErrorDialogState = {}

--- a/feature/my/src/main/java/com/hankki/feature/my/newjogbo/NewJogboState.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/newjogbo/NewJogboState.kt
@@ -3,6 +3,6 @@ package com.hankki.feature.my.newjogbo
 data class NewJogboState(
     val title : String = "",
     val tags : String = "",
-    val isButtonEnabled : Boolean = false,
+    val buttonEnabled : Boolean = false,
     var errorDialogState: Boolean = false
 )

--- a/feature/my/src/main/java/com/hankki/feature/my/newjogbo/NewJogboViewModel.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/newjogbo/NewJogboViewModel.kt
@@ -42,7 +42,7 @@ class NewJogboViewModel @Inject constructor(
         val tagsList = tags.replace("#", "")
 
         _newJogboState.value = _newJogboState.value.copy(
-            isButtonEnabled = title.isNotEmpty() && tagsList.isNotEmpty()
+            buttonEnabled = title.isNotEmpty() && tagsList.isNotEmpty()
         )
     }
 
@@ -53,6 +53,9 @@ class NewJogboViewModel @Inject constructor(
 
     fun createNewJogbo() {
         viewModelScope.launch {
+            _newJogboState.value = _newJogboState.value.copy(
+                buttonEnabled = false
+            )
             myRepository.createNewJogbo(
                 NewJogboEntity(
                     title = _newJogboState.value.title,

--- a/feature/my/src/main/res/values/strings.xml
+++ b/feature/my/src/main/res/values/strings.xml
@@ -13,7 +13,7 @@
 
     <!--my page-->
     <string name="my">MY</string>
-    <string name="message_user_name">%1$s 님\n한끼 잘 챙겨 드세요</string>
+    <string name="message_user_name">%1$s님\n한끼 잘 챙겨 드세요</string>
     <string name="description_store_report">내가 제보한 식당</string>
     <string name="description_store_like">좋아요 누른 식당</string>
     <string name="terms_of_use">약관 및 정책</string>

--- a/feature/storedetail/build.gradle.kts
+++ b/feature/storedetail/build.gradle.kts
@@ -15,4 +15,5 @@ dependencies {
     //other
     implementation(libs.coil.compose)
     implementation(libs.accompanist.systemuicontroller)
+    implementation(libs.retrofit.core)
 }

--- a/feature/storedetail/src/main/java/com/hankki/feature/storedetail/StoreDetailRoute.kt
+++ b/feature/storedetail/src/main/java/com/hankki/feature/storedetail/StoreDetailRoute.kt
@@ -64,6 +64,7 @@ fun StoreDetailRoute(
     navigateUp: () -> Unit,
     navigateToAddNewJogbo: () -> Unit,
     onShowSnackBar: (String, Long) -> Unit,
+    onShowTextSnackBar: (String) -> Unit,
     viewModel: StoreDetailViewModel = hiltViewModel(),
 ) {
     val storeState by viewModel.storeState.collectAsStateWithLifecycle()
@@ -82,6 +83,10 @@ fun StoreDetailRoute(
             when (sideEffect) {
                 StoreDetailSideEffect.NavigateUp -> navigateUp()
                 StoreDetailSideEffect.NavigateToAddNewJogbo -> navigateToAddNewJogbo()
+                StoreDetailSideEffect.ShowTextSnackBar -> {
+                    onShowTextSnackBar("이미 삭제된 식당입니다 ")
+                    navigateUp()
+                }
             }
         }
     }

--- a/feature/storedetail/src/main/java/com/hankki/feature/storedetail/StoreDetailSideEffect.kt
+++ b/feature/storedetail/src/main/java/com/hankki/feature/storedetail/StoreDetailSideEffect.kt
@@ -3,4 +3,5 @@ package com.hankki.feature.storedetail
 sealed class StoreDetailSideEffect {
     data object NavigateUp : StoreDetailSideEffect()
     data object NavigateToAddNewJogbo : StoreDetailSideEffect()
+    data object ShowTextSnackBar : StoreDetailSideEffect()
 }

--- a/feature/storedetail/src/main/java/com/hankki/feature/storedetail/StoreDetailViewModel.kt
+++ b/feature/storedetail/src/main/java/com/hankki/feature/storedetail/StoreDetailViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import retrofit2.HttpException
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -48,8 +49,12 @@ class StoreDetailViewModel @Inject constructor(
             )
             storeDetailRepository.getStoreDetail(storeId).onSuccess {
                 setStoreDetail(it)
-            }.onFailure {
+            }.onFailure { error ->
                 _storeState.value = _storeState.value.copy(storeDetail = UiState.Failure)
+
+                if (error is HttpException && error.code() == DO_NOT_EXISTS_ERROR) {
+                    _sideEffects.emit(StoreDetailSideEffect.ShowTextSnackBar)
+                }
             }
         }
     }
@@ -173,5 +178,9 @@ class StoreDetailViewModel @Inject constructor(
                     Timber.e("Failed to delete store123: ${error.message}")
                 }
         }
+    }
+
+    companion object {
+        private const val DO_NOT_EXISTS_ERROR: Int = 404
     }
 }

--- a/feature/storedetail/src/main/java/com/hankki/feature/storedetail/navigation/navigateStoreDetail.kt
+++ b/feature/storedetail/src/main/java/com/hankki/feature/storedetail/navigation/navigateStoreDetail.kt
@@ -17,7 +17,8 @@ fun NavGraphBuilder.storeDetailNavGraph(
     navigateUp: () -> Unit,
     navigateToAddNewJogbo: () -> Unit,
     onShowSnackBar: (String, Long) -> Unit,
-) {
+    onShowTextSnackBar: (String) -> Unit,
+    ) {
     composable<StoreDetail> { backStackEntry ->
         val items = backStackEntry.toRoute<StoreDetail>()
         StoreDetailRoute(
@@ -25,6 +26,7 @@ fun NavGraphBuilder.storeDetailNavGraph(
             navigateUp = navigateUp,
             navigateToAddNewJogbo = navigateToAddNewJogbo,
             onShowSnackBar = onShowSnackBar,
+            onShowTextSnackBar = onShowTextSnackBar
         )
     }
 }


### PR DESCRIPTION
- closed #223

## *⛳️ Work Description*
- 족보 0개일때 완전히 삭제 버튼 비허용
- 족보 디테일 전체 화면 스크롤로 변경
- 마이페이지 이름 __ 님 > __님으로 변경
- 족보 삭제 및 족보 생성 버튼 클릭 막기
- 없는 식당을 클릭할 경우 뒤로가기 처리
- 텍스트필드 완료 클릭시 다음텍스트필드로 이동

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->
|전|후|
|:---:|:---:|
|<img src="https://github.com/user-attachments/assets/c5c92abb-199a-418f-b4fd-1887b17610bf" width=270 />|<img src="https://github.com/user-attachments/assets/f1b57791-116d-4cab-a76c-90f90892e03b" width=270 />|
|<img src="https://github.com/user-attachments/assets/f55c1970-cf81-4e85-9063-22a5efccc774" width=270 />|<img src="https://github.com/user-attachments/assets/ded9c8b3-0e8c-44ed-b149-e63d36e4e796" width=270 />|
|<img src="https://github.com/user-attachments/assets/29185979-30bc-4933-8728-30299c04ec15" width=270 />|<img src="https://github.com/user-attachments/assets/fbd951b7-8b11-4816-80bc-c1bbeef0918b" width=270 />|
|<img src="https://github.com/user-attachments/assets/c794a7d4-3b1f-4ab5-86e4-24f152916934" width=270 />|<img src="https://github.com/user-attachments/assets/37832110-e82d-49ef-a749-6c7ce603c23f" width=270 />|
<!--|<img src="" width=270 />|<img src="" width=270 />|->


## *📢 To Reviewers*
- lazy column의 item은 fill max size를 사용해도 wrap content처럼 작동한다고 하여 동멘님의 화면 비율 코드를 가져와 사용했습니다!
- 현재 기능이 다 정상적으로 작동하나 myjogbo 쪽 코드가 마음에 들지않아... 고치는 중..! 28일전까지 최대한 해보나.. 그전까지 못하면 2차 스프린트 전까지 하겠습니다 ... : -(
