### PR TITLE
[Fix #238] Align store item row to center

### DIFF
--- a/feature/my/src/main/java/com/hankki/feature/my/component/StoreItem.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/component/StoreItem.kt
@@ -75,7 +75,7 @@ fun StoreItem(
                 .weight(1f),
             verticalArrangement = Arrangement.Center
         ) {
-            Row {
+            Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     text = name,
                     style = HankkiTheme.typography.suitSub2,


### PR DESCRIPTION
- closed #238

## *⛳️ Work Description*
- store item 식당 이름과 칩이 수직 중앙 정렬이 안된것을 발견하여...수정했어요

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->
|전|후|
|:---:|:---:|
|<img src="https://github.com/user-attachments/assets/3a981d6e-76b5-4e04-87ec-9c9f4dc5acb0" width=270 />|<img src="https://github.com/user-attachments/assets/343dab72-f3fd-461c-85fb-fb2b065a3e3c" width=270 />|


## *📢 To Reviewers*
- 이제 진짜...끝...
