### PR TITLE
[Feature/#270] SnackBar의 prop drilling issue를 해결하고, 사용성을 개선합니다.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,7 +3,6 @@ import com.hankki.build_logic.setNamespace
 
 plugins {
     alias(libs.plugins.hankki.application)
-    alias(libs.plugins.android.application)
     alias(libs.plugins.baselineprofile)
 }
 

--- a/build-logic/src/main/java/hankki.android.data.gradle.kts
+++ b/build-logic/src/main/java/hankki.android.data.gradle.kts
@@ -26,10 +26,6 @@ dependencies {
     // timber
     implementation(libs.findLibrary("timber").get())
 
-    // immutable
-    implementation(libs.findLibrary("kotlinx.immutable").get())
-
     // retrofit
-    implementation(libs.findLibrary("retrofit.core").get())
-    implementation(libs.findLibrary("retrofit.kotlin.serialization").get())
+    implementation(libs.findBundle("retrofit").get())
 }

--- a/core/designsystem/src/main/java/com/hankki/core/designsystem/event/SnackBarTrigger.kt
+++ b/core/designsystem/src/main/java/com/hankki/core/designsystem/event/SnackBarTrigger.kt
@@ -1,0 +1,16 @@
+package com.hankki.core.designsystem.event
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+val LocalSnackBarTrigger = staticCompositionLocalOf<(String) -> Unit> {
+    error("No SnackBar provided")
+}
+
+val LocalSnackBarWithButtonTrigger = staticCompositionLocalOf<(String, Long) -> Unit> {
+    error("No SnackBar provided")
+}
+
+
+val LocalWhiteSnackBarTrigger = staticCompositionLocalOf<(String, Long) -> Unit> {
+    error("No SnackBar provided")
+}

--- a/core/designsystem/src/main/java/com/hankki/core/designsystem/event/SnackBarTrigger.kt
+++ b/core/designsystem/src/main/java/com/hankki/core/designsystem/event/SnackBarTrigger.kt
@@ -6,11 +6,11 @@ val LocalSnackBarTrigger = staticCompositionLocalOf<(String) -> Unit> {
     error("No SnackBar provided")
 }
 
-val LocalSnackBarWithButtonTrigger = staticCompositionLocalOf<(String, Long) -> Unit> {
-    error("No SnackBar provided")
+val LocalButtonSnackBarTrigger = staticCompositionLocalOf<(String, Long) -> Unit> {
+    error("No ButtonSnackBar provided")
 }
 
 
 val LocalWhiteSnackBarTrigger = staticCompositionLocalOf<(String, Long) -> Unit> {
-    error("No SnackBar provided")
+    error("No WhiteSnackBar provided")
 }

--- a/core/designsystem/src/main/java/com/hankki/core/designsystem/event/SnackBarTrigger.kt
+++ b/core/designsystem/src/main/java/com/hankki/core/designsystem/event/SnackBarTrigger.kt
@@ -10,7 +10,6 @@ val LocalButtonSnackBarTrigger = staticCompositionLocalOf<(String, Long) -> Unit
     error("No ButtonSnackBar provided")
 }
 
-
 val LocalWhiteSnackBarTrigger = staticCompositionLocalOf<(String, Long) -> Unit> {
     error("No WhiteSnackBar provided")
 }

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -44,8 +44,7 @@ dependencies {
     implementation(platform(libs.okhttp.bom))
     implementation(libs.bundles.okhttp)
 
-    implementation(libs.retrofit.core)
-    implementation(libs.retrofit.kotlin.serialization)
+    implementation(libs.bundles.retrofit)
 
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.timber)

--- a/feature/home/src/main/java/com/hankki/feature/home/HomeRoute.kt
+++ b/feature/home/src/main/java/com/hankki/feature/home/HomeRoute.kt
@@ -88,7 +88,7 @@ import com.hankki.core.designsystem.theme.Gray900
 import com.hankki.core.designsystem.theme.HankkiTheme
 import com.hankki.core.designsystem.theme.White
 import com.hankki.core.designsystem.event.LocalSnackBarTrigger
-import com.hankki.core.designsystem.event.LocalSnackBarWithButtonTrigger
+import com.hankki.core.designsystem.event.LocalButtonSnackBarTrigger
 import com.hankki.feature.home.MapConstants.CAN_SEE_TITLE_ZOOM
 import com.hankki.feature.home.MapConstants.DEFAULT_ZOOM
 import com.hankki.feature.home.R.drawable.ic_coin
@@ -140,7 +140,7 @@ fun HomeRoute(
     val state by viewModel.state.collectAsStateWithLifecycle()
 
     val snackBar = LocalSnackBarTrigger.current
-    val buttonSnackBar = LocalSnackBarWithButtonTrigger.current
+    val buttonSnackBar = LocalButtonSnackBarTrigger.current
 
     val focusLocationProviderClient = remember {
         LocationServices.getFusedLocationProviderClient(context)

--- a/feature/home/src/main/java/com/hankki/feature/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/hankki/feature/home/navigation/HomeNavigation.kt
@@ -17,8 +17,6 @@ fun NavController.navigateHome(
 
 fun NavGraphBuilder.homeNavGraph(
     paddingValues: PaddingValues,
-    onShowSnackBar: (String, Long) -> Unit,
-    onShowTextSnackBar: (String) -> Unit,
     navigateStoreDetail: (Long) -> Unit,
     navigateToUniversitySelection: () -> Unit,
     navigateToAddNewJogbo: () -> Unit,
@@ -26,8 +24,6 @@ fun NavGraphBuilder.homeNavGraph(
     composable<Home> {
         HomeRoute(
             paddingValues = paddingValues,
-            onShowSnackBar = onShowSnackBar,
-            onShowTextSnackBar = onShowTextSnackBar,
             navigateStoreDetail = navigateStoreDetail,
             navigateToUniversitySelection = navigateToUniversitySelection,
             navigateToAddNewJogbo = navigateToAddNewJogbo

--- a/feature/main/src/main/java/com/hankki/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/hankki/feature/main/MainScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -59,6 +60,9 @@ import com.hankki.core.designsystem.theme.HankkiTheme
 import com.hankki.core.designsystem.theme.HankkijogboTheme
 import com.hankki.core.designsystem.theme.Red500
 import com.hankki.core.designsystem.theme.White
+import com.hankki.core.designsystem.event.LocalSnackBarTrigger
+import com.hankki.core.designsystem.event.LocalSnackBarWithButtonTrigger
+import com.hankki.core.designsystem.event.LocalWhiteSnackBarTrigger
 import com.hankki.feature.home.navigation.Home
 import com.hankki.feature.home.navigation.homeNavGraph
 import com.hankki.feature.login.navigation.Login
@@ -134,206 +138,253 @@ internal fun MainScreen(
         }
     }
 
-    Scaffold(
-        content = { paddingValue ->
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-            ) {
-                NavHost(
-                    navController = navigator.navController,
-                    startDestination = navigator.startDestination,
-                    enterTransition = { EnterTransition.None },
-                    exitTransition = { ExitTransition.None },
-                    popEnterTransition = { EnterTransition.None },
-                    popExitTransition = { ExitTransition.None }
+    CompositionLocalProvider(
+        LocalSnackBarTrigger provides onShowErrorSnackBar,
+        LocalWhiteSnackBarTrigger provides onShowWhiteSnackBarWithButton,
+        LocalSnackBarWithButtonTrigger provides onShowTextSnackBarWithButton,
+    ) {
+        Scaffold(
+            content = { paddingValue ->
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
                 ) {
-                    splashNavGraph(
-                        navigateToHome = {
-                            val navOptions = navOptions {
-                                popUpTo(navigator.navController.graph.findStartDestination().id) {
-                                    inclusive = true
-                                }
-                                launchSingleTop = true
-                            }
-                            navigator.navigateToHome(navOptions = navOptions)
-                        },
-                        navigateToLogIn = {
-                            val navOptions = navOptions {
-                                popUpTo(navigator.navController.graph.findStartDestination().id) {
-                                    inclusive = true
-                                }
-                                launchSingleTop = true
-                            }
-                            navigator.navigateToLogin(
-                                navOptions = navOptions
-                            )
-                        },
-                    )
-                    homeNavGraph(
-                        paddingValues = paddingValue,
-                        onShowSnackBar = onShowTextSnackBarWithButton,
-                        onShowTextSnackBar = onShowErrorSnackBar,
-                        navigateStoreDetail = navigator::navigateToStoreDetail,
-                        navigateToUniversitySelection = navigator::navigateToUniversity,
-                        navigateToAddNewJogbo = navigator::navigateToNewJogbo
-                    )
-                    reportNavGraph(
-                        navigateReport = { latitude, longitude, location, address ->
-                            val navOptions = navOptions {
-                                popUpTo<Home> {
-                                    inclusive = false
-                                }
-                                launchSingleTop = true
-                            }
-                            navigator.navigateToReport(
-                                LocationModel(
-                                    latitude,
-                                    longitude,
-                                    location,
-                                    address
-                                ), navOptions
-                            )
-                        },
-                        navigateToSearchStore = {
-                            navigator.navigateToSearchStore()
-                        },
-                        navigateUp = navigator::navigateUpIfNotHome,
-                        navigateToReportFinish = { count, storeName, storeId ->
-                            val navOptions = navOptions {
-                                popUpTo<Home> {
-                                    inclusive = false
-                                }
-                                launchSingleTop = true
-                            }
-                            navigator.navigateToReportFinish(
-                                count,
-                                storeName,
-                                storeId,
-                                navOptions
-                            )
-                        },
-                        navigateToHome = {
-                            val navOptions = navOptions {
-                                popUpTo<Home> {
-                                    inclusive = false
-                                }
-                                launchSingleTop = true
-                            }
-                            navigator.navigateToHome(navOptions)
-                        },
-                        navigateToStoreDetail = { storeId ->
-                            navigator.navigateToStoreDetail(storeId)
-                        },
-                        navigateToAddNewJogbo = navigator::navigateToNewJogbo,
-                        onShowSnackBar = onShowWhiteSnackBarWithButton,
-                        onShowTextSnackBar = onShowErrorSnackBar
-                    )
-                    myNavGraph(
-                        paddingValues = paddingValue,
-                        navigateUp = navigator::navigateUpIfNotHome,
-                        navigateToMyJogbo = navigator::navigateToMyJogbo,
-                        navigateToMyStore = navigator::navigateToMyStore,
-                        navigateToJogboDetail = navigator::navigateToMyJogboDetail,
-                        navigateToNewJogbo = navigator::navigateToNewJogbo,
-                        navigateToStoreDetail = navigator::navigateToStoreDetail,
-                        navigateToHome = {
-                            val navOptions = navOptions {
-                                popUpTo<Home> {
-                                    inclusive = false
-                                }
-                                launchSingleTop = true
-                            }
-                            navigator.navigateToHome(navOptions)
-                        }
-                    )
-                    loginNavGraph(
-                        navigateToHome = {
-                            val navOptions = navOptions {
-                                popUpTo<Login> {
-                                    inclusive = true
-                                }
-                                launchSingleTop = true
-                            }
-                            navigator.navigateToHome(navOptions = navOptions)
-                        },
-                        navigateToOnboarding = {
-                            val navOptions = navOptions {
-                                popUpTo<Login> {
-                                    inclusive = true
-                                }
-                                launchSingleTop = true
-                            }
-                            navigator.navigateToOnboarding(navOptions)
-                        }
-                    )
-
-                    onboardingNavGraph(
-                        navigateToUniversity = {
-                            val navOptions = navOptions {
-                                popUpTo<Onboarding> {
-                                    inclusive = true
-                                }
-                                launchSingleTop = true
-                            }
-                            navigator.navigateToUniversity(navOptions)
-                        }
-                    )
-                    universitySelectionNavGraph(
-                        navigateToHome = {
-                            val navOptions = navOptions {
-                                popUpTo<UniversitySelection> {
-                                    inclusive = true
-                                }
-                                launchSingleTop = true
-                            }
-                            navigator.navigateToHome(
-                                navOptions = navOptions
-                            )
-                        }
-                    )
-                    storeDetailNavGraph(
+                    NavHost(
                         navController = navigator.navController,
-                        navigateUp = navigator::navigateUpIfNotHome,
-                        navigateToAddNewJogbo = navigator::navigateToNewJogbo,
-                        onShowSnackBar = onShowTextSnackBarWithButton,
-                        onShowErrorSnackBar = onShowErrorSnackBar,
-                        navigateToAddMenu = navigator::navigateToAddMenu,
-                        navigateToEditMenu = navigator::navigateToEditMenu,
-                        navigateToHome = {
-                            val navOptions = navOptions {
-                                popUpTo<Home> {
-                                    inclusive = false
-                                }
-                                launchSingleTop = true
-                            }
-                            navigator.navigateToHome(navOptions)
-                        }
-                    )
-                }
-
-                if (!isConnected) {
-                    SingleButtonDialog(
-                        title = "네트워크 오류가 발생했어요",
-                        description = "네트워크 연결 상태를 확인하고 다시 시도해주세요",
-                        buttonTitle = "확인"
+                        startDestination = navigator.startDestination,
+                        enterTransition = { EnterTransition.None },
+                        exitTransition = { ExitTransition.None },
+                        popEnterTransition = { EnterTransition.None },
+                        popExitTransition = { ExitTransition.None }
                     ) {
-                        navigator.navigateUpIfNotHome()
+                        splashNavGraph(
+                            navigateToHome = {
+                                val navOptions = navOptions {
+                                    popUpTo(navigator.navController.graph.findStartDestination().id) {
+                                        inclusive = true
+                                    }
+                                    launchSingleTop = true
+                                }
+                                navigator.navigateToHome(navOptions = navOptions)
+                            },
+                            navigateToLogIn = {
+                                val navOptions = navOptions {
+                                    popUpTo(navigator.navController.graph.findStartDestination().id) {
+                                        inclusive = true
+                                    }
+                                    launchSingleTop = true
+                                }
+                                navigator.navigateToLogin(
+                                    navOptions = navOptions
+                                )
+                            },
+                        )
+                        homeNavGraph(
+                            paddingValues = paddingValue,
+                            navigateStoreDetail = navigator::navigateToStoreDetail,
+                            navigateToUniversitySelection = navigator::navigateToUniversity,
+                            navigateToAddNewJogbo = navigator::navigateToNewJogbo
+                        )
+                        reportNavGraph(
+                            navigateReport = { latitude, longitude, location, address ->
+                                val navOptions = navOptions {
+                                    popUpTo<Home> {
+                                        inclusive = false
+                                    }
+                                    launchSingleTop = true
+                                }
+                                navigator.navigateToReport(
+                                    LocationModel(
+                                        latitude,
+                                        longitude,
+                                        location,
+                                        address
+                                    ), navOptions
+                                )
+                            },
+                            navigateToSearchStore = {
+                                navigator.navigateToSearchStore()
+                            },
+                            navigateUp = navigator::navigateUpIfNotHome,
+                            navigateToReportFinish = { count, storeName, storeId ->
+                                val navOptions = navOptions {
+                                    popUpTo<Home> {
+                                        inclusive = false
+                                    }
+                                    launchSingleTop = true
+                                }
+                                navigator.navigateToReportFinish(
+                                    count,
+                                    storeName,
+                                    storeId,
+                                    navOptions
+                                )
+                            },
+                            navigateToHome = {
+                                val navOptions = navOptions {
+                                    popUpTo<Home> {
+                                        inclusive = false
+                                    }
+                                    launchSingleTop = true
+                                }
+                                navigator.navigateToHome(navOptions)
+                            },
+                            navigateToStoreDetail = { storeId ->
+                                navigator.navigateToStoreDetail(storeId)
+                            },
+                            navigateToAddNewJogbo = navigator::navigateToNewJogbo,
+                            onShowSnackBar = onShowWhiteSnackBarWithButton,
+                            onShowTextSnackBar = onShowErrorSnackBar
+                        )
+                        myNavGraph(
+                            paddingValues = paddingValue,
+                            navigateUp = navigator::navigateUpIfNotHome,
+                            navigateToMyJogbo = navigator::navigateToMyJogbo,
+                            navigateToMyStore = navigator::navigateToMyStore,
+                            navigateToJogboDetail = navigator::navigateToMyJogboDetail,
+                            navigateToNewJogbo = navigator::navigateToNewJogbo,
+                            navigateToStoreDetail = navigator::navigateToStoreDetail,
+                            navigateToHome = {
+                                val navOptions = navOptions {
+                                    popUpTo<Home> {
+                                        inclusive = false
+                                    }
+                                    launchSingleTop = true
+                                }
+                                navigator.navigateToHome(navOptions)
+                            }
+                        )
+                        loginNavGraph(
+                            navigateToHome = {
+                                val navOptions = navOptions {
+                                    popUpTo<Login> {
+                                        inclusive = true
+                                    }
+                                    launchSingleTop = true
+                                }
+                                navigator.navigateToHome(navOptions = navOptions)
+                            },
+                            navigateToOnboarding = {
+                                val navOptions = navOptions {
+                                    popUpTo<Login> {
+                                        inclusive = true
+                                    }
+                                    launchSingleTop = true
+                                }
+                                navigator.navigateToOnboarding(navOptions)
+                            }
+                        )
+
+                        onboardingNavGraph(
+                            navigateToUniversity = {
+                                val navOptions = navOptions {
+                                    popUpTo<Onboarding> {
+                                        inclusive = true
+                                    }
+                                    launchSingleTop = true
+                                }
+                                navigator.navigateToUniversity(navOptions)
+                            }
+                        )
+                        universitySelectionNavGraph(
+                            navigateToHome = {
+                                val navOptions = navOptions {
+                                    popUpTo<UniversitySelection> {
+                                        inclusive = true
+                                    }
+                                    launchSingleTop = true
+                                }
+                                navigator.navigateToHome(
+                                    navOptions = navOptions
+                                )
+                            }
+                        )
+                        storeDetailNavGraph(
+                            navController = navigator.navController,
+                            navigateUp = navigator::navigateUpIfNotHome,
+                            navigateToAddNewJogbo = navigator::navigateToNewJogbo,
+                            onShowSnackBar = onShowTextSnackBarWithButton,
+                            onShowErrorSnackBar = onShowErrorSnackBar,
+                            navigateToAddMenu = navigator::navigateToAddMenu,
+                            navigateToEditMenu = navigator::navigateToEditMenu,
+                            navigateToHome = {
+                                val navOptions = navOptions {
+                                    popUpTo<Home> {
+                                        inclusive = false
+                                    }
+                                    launchSingleTop = true
+                                }
+                                navigator.navigateToHome(navOptions)
+                            }
+                        )
+                    }
+
+                    if (!isConnected) {
+                        SingleButtonDialog(
+                            title = "네트워크 오류가 발생했어요",
+                            description = "네트워크 연결 상태를 확인하고 다시 시도해주세요",
+                            buttonTitle = "확인"
+                        ) {
+                            navigator.navigateUpIfNotHome()
+                        }
+                    }
+
+                    SnackbarHost(
+                        hostState = whiteSnackBarWithButtonHostState,
+                        modifier = Modifier
+                            .align(Alignment.TopCenter)
+                            .statusBarsPadding()
+                            .padding(top = 35.dp)
+                    ) { snackBarData ->
+                        runCatching {
+                            val (message, jogboId) = snackBarData.visuals.message.split("/")
+
+                            HankkiWhiteSnackBarWithButton(
+                                message = message
+                            ) {
+                                snackBarData.dismiss()
+
+                                navigator.navigateToMyJogboDetail(
+                                    jogboId.toLong()
+                                )
+                            }
+                        }.onFailure {
+                            HankkiWhiteSnackBarWithButton(
+                                message = "오류가 발생했어요",
+                                buttonText = "닫기"
+                            ) {
+                                snackBarData.dismiss()
+                            }
+                        }
                     }
                 }
+            },
+            bottomBar = {
+                MainBottomBar(
+                    visible = navigator.shouldShowBottomBar(),
+                    tabs = MainTab.entries.toPersistentList(),
+                    currentTab = navigator.currentTab,
+                    onTabSelected = {
+                        navigator.navigate(it)
 
-                SnackbarHost(
-                    hostState = whiteSnackBarWithButtonHostState,
-                    modifier = Modifier
-                        .align(Alignment.TopCenter)
-                        .statusBarsPadding()
-                        .padding(top = 35.dp)
-                ) { snackBarData ->
+                        tracker.track(
+                            EventType.CLICK,
+                            "Nav_${it.name}"
+                        )
+                    }
+                )
+            },
+            snackbarHost = {
+                SnackbarHost(hostState = errorSnackBarHostState) { snackBarData ->
+                    HankkiTextSnackBar(message = snackBarData.visuals.message)
+                }
+
+                SnackbarHost(hostState = textSnackBarWithButtonHostState) { snackBarData ->
                     runCatching {
                         val (message, jogboId) = snackBarData.visuals.message.split("/")
 
-                        HankkiWhiteSnackBarWithButton(
-                            message = message
+                        HankkiTextSnackBarWithButton(
+                            message = message,
                         ) {
                             snackBarData.dismiss()
 
@@ -342,60 +393,17 @@ internal fun MainScreen(
                             )
                         }
                     }.onFailure {
-                        HankkiWhiteSnackBarWithButton(
-                            message = "오류가 발생했어요",
+                        HankkiTextSnackBarWithButton(
+                            message = snackBarData.visuals.message,
                             buttonText = "닫기"
                         ) {
                             snackBarData.dismiss()
                         }
                     }
                 }
-            }
-        },
-        bottomBar = {
-            MainBottomBar(
-                visible = navigator.shouldShowBottomBar(),
-                tabs = MainTab.entries.toPersistentList(),
-                currentTab = navigator.currentTab,
-                onTabSelected = {
-                    navigator.navigate(it)
-
-                    tracker.track(
-                        EventType.CLICK,
-                        "Nav_${it.name}"
-                    )
-                }
-            )
-        },
-        snackbarHost = {
-            SnackbarHost(hostState = errorSnackBarHostState) { snackBarData ->
-                HankkiTextSnackBar(message = snackBarData.visuals.message)
-            }
-
-            SnackbarHost(hostState = textSnackBarWithButtonHostState) { snackBarData ->
-                runCatching {
-                    val (message, jogboId) = snackBarData.visuals.message.split("/")
-
-                    HankkiTextSnackBarWithButton(
-                        message = message,
-                    ) {
-                        snackBarData.dismiss()
-
-                        navigator.navigateToMyJogboDetail(
-                            jogboId.toLong()
-                        )
-                    }
-                }.onFailure {
-                    HankkiTextSnackBarWithButton(
-                        message = snackBarData.visuals.message,
-                        buttonText = "닫기"
-                    ) {
-                        snackBarData.dismiss()
-                    }
-                }
-            }
-        },
-    )
+            },
+        )
+    }
 }
 
 @Composable

--- a/feature/main/src/main/java/com/hankki/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/hankki/feature/main/MainScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
@@ -54,15 +55,15 @@ import com.hankki.core.designsystem.component.dialog.SingleButtonDialog
 import com.hankki.core.designsystem.component.snackbar.HankkiTextSnackBar
 import com.hankki.core.designsystem.component.snackbar.HankkiTextSnackBarWithButton
 import com.hankki.core.designsystem.component.snackbar.HankkiWhiteSnackBarWithButton
+import com.hankki.core.designsystem.event.LocalSnackBarTrigger
+import com.hankki.core.designsystem.event.LocalSnackBarWithButtonTrigger
+import com.hankki.core.designsystem.event.LocalWhiteSnackBarTrigger
 import com.hankki.core.designsystem.theme.Gray100
 import com.hankki.core.designsystem.theme.Gray400
 import com.hankki.core.designsystem.theme.HankkiTheme
 import com.hankki.core.designsystem.theme.HankkijogboTheme
 import com.hankki.core.designsystem.theme.Red500
 import com.hankki.core.designsystem.theme.White
-import com.hankki.core.designsystem.event.LocalSnackBarTrigger
-import com.hankki.core.designsystem.event.LocalSnackBarWithButtonTrigger
-import com.hankki.core.designsystem.event.LocalWhiteSnackBarTrigger
 import com.hankki.feature.home.navigation.Home
 import com.hankki.feature.home.navigation.homeNavGraph
 import com.hankki.feature.login.navigation.Login
@@ -145,217 +146,12 @@ internal fun MainScreen(
     ) {
         Scaffold(
             content = { paddingValue ->
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                ) {
-                    NavHost(
-                        navController = navigator.navController,
-                        startDestination = navigator.startDestination,
-                        enterTransition = { EnterTransition.None },
-                        exitTransition = { ExitTransition.None },
-                        popEnterTransition = { EnterTransition.None },
-                        popExitTransition = { ExitTransition.None }
-                    ) {
-                        splashNavGraph(
-                            navigateToHome = {
-                                val navOptions = navOptions {
-                                    popUpTo(navigator.navController.graph.findStartDestination().id) {
-                                        inclusive = true
-                                    }
-                                    launchSingleTop = true
-                                }
-                                navigator.navigateToHome(navOptions = navOptions)
-                            },
-                            navigateToLogIn = {
-                                val navOptions = navOptions {
-                                    popUpTo(navigator.navController.graph.findStartDestination().id) {
-                                        inclusive = true
-                                    }
-                                    launchSingleTop = true
-                                }
-                                navigator.navigateToLogin(
-                                    navOptions = navOptions
-                                )
-                            },
-                        )
-                        homeNavGraph(
-                            paddingValues = paddingValue,
-                            navigateStoreDetail = navigator::navigateToStoreDetail,
-                            navigateToUniversitySelection = navigator::navigateToUniversity,
-                            navigateToAddNewJogbo = navigator::navigateToNewJogbo
-                        )
-                        reportNavGraph(
-                            navigateReport = { latitude, longitude, location, address ->
-                                val navOptions = navOptions {
-                                    popUpTo<Home> {
-                                        inclusive = false
-                                    }
-                                    launchSingleTop = true
-                                }
-                                navigator.navigateToReport(
-                                    LocationModel(
-                                        latitude,
-                                        longitude,
-                                        location,
-                                        address
-                                    ), navOptions
-                                )
-                            },
-                            navigateToSearchStore = {
-                                navigator.navigateToSearchStore()
-                            },
-                            navigateUp = navigator::navigateUpIfNotHome,
-                            navigateToReportFinish = { count, storeName, storeId ->
-                                val navOptions = navOptions {
-                                    popUpTo<Home> {
-                                        inclusive = false
-                                    }
-                                    launchSingleTop = true
-                                }
-                                navigator.navigateToReportFinish(
-                                    count,
-                                    storeName,
-                                    storeId,
-                                    navOptions
-                                )
-                            },
-                            navigateToHome = {
-                                val navOptions = navOptions {
-                                    popUpTo<Home> {
-                                        inclusive = false
-                                    }
-                                    launchSingleTop = true
-                                }
-                                navigator.navigateToHome(navOptions)
-                            },
-                            navigateToStoreDetail = { storeId ->
-                                navigator.navigateToStoreDetail(storeId)
-                            },
-                            navigateToAddNewJogbo = navigator::navigateToNewJogbo,
-                        )
-                        myNavGraph(
-                            paddingValues = paddingValue,
-                            navigateUp = navigator::navigateUpIfNotHome,
-                            navigateToMyJogbo = navigator::navigateToMyJogbo,
-                            navigateToMyStore = navigator::navigateToMyStore,
-                            navigateToJogboDetail = navigator::navigateToMyJogboDetail,
-                            navigateToNewJogbo = navigator::navigateToNewJogbo,
-                            navigateToStoreDetail = navigator::navigateToStoreDetail,
-                            navigateToHome = {
-                                val navOptions = navOptions {
-                                    popUpTo<Home> {
-                                        inclusive = false
-                                    }
-                                    launchSingleTop = true
-                                }
-                                navigator.navigateToHome(navOptions)
-                            }
-                        )
-                        loginNavGraph(
-                            navigateToHome = {
-                                val navOptions = navOptions {
-                                    popUpTo<Login> {
-                                        inclusive = true
-                                    }
-                                    launchSingleTop = true
-                                }
-                                navigator.navigateToHome(navOptions = navOptions)
-                            },
-                            navigateToOnboarding = {
-                                val navOptions = navOptions {
-                                    popUpTo<Login> {
-                                        inclusive = true
-                                    }
-                                    launchSingleTop = true
-                                }
-                                navigator.navigateToOnboarding(navOptions)
-                            }
-                        )
-
-                        onboardingNavGraph(
-                            navigateToUniversity = {
-                                val navOptions = navOptions {
-                                    popUpTo<Onboarding> {
-                                        inclusive = true
-                                    }
-                                    launchSingleTop = true
-                                }
-                                navigator.navigateToUniversity(navOptions)
-                            }
-                        )
-                        universitySelectionNavGraph(
-                            navigateToHome = {
-                                val navOptions = navOptions {
-                                    popUpTo<UniversitySelection> {
-                                        inclusive = true
-                                    }
-                                    launchSingleTop = true
-                                }
-                                navigator.navigateToHome(
-                                    navOptions = navOptions
-                                )
-                            }
-                        )
-                        storeDetailNavGraph(
-                            navController = navigator.navController,
-                            navigateUp = navigator::navigateUpIfNotHome,
-                            navigateToAddNewJogbo = navigator::navigateToNewJogbo,
-                            onShowSnackBar = onShowTextSnackBarWithButton,
-                            onShowErrorSnackBar = onShowErrorSnackBar,
-                            navigateToAddMenu = navigator::navigateToAddMenu,
-                            navigateToEditMenu = navigator::navigateToEditMenu,
-                            navigateToHome = {
-                                val navOptions = navOptions {
-                                    popUpTo<Home> {
-                                        inclusive = false
-                                    }
-                                    launchSingleTop = true
-                                }
-                                navigator.navigateToHome(navOptions)
-                            }
-                        )
-                    }
-
-                    if (!isConnected) {
-                        SingleButtonDialog(
-                            title = "네트워크 오류가 발생했어요",
-                            description = "네트워크 연결 상태를 확인하고 다시 시도해주세요",
-                            buttonTitle = "확인"
-                        ) {
-                            navigator.navigateUpIfNotHome()
-                        }
-                    }
-
-                    SnackbarHost(
-                        hostState = whiteSnackBarWithButtonHostState,
-                        modifier = Modifier
-                            .align(Alignment.TopCenter)
-                            .statusBarsPadding()
-                            .padding(top = 35.dp)
-                    ) { snackBarData ->
-                        runCatching {
-                            val (message, jogboId) = snackBarData.visuals.message.split("/")
-
-                            HankkiWhiteSnackBarWithButton(
-                                message = message
-                            ) {
-                                snackBarData.dismiss()
-
-                                navigator.navigateToMyJogboDetail(
-                                    jogboId.toLong()
-                                )
-                            }
-                        }.onFailure {
-                            HankkiWhiteSnackBarWithButton(
-                                message = "오류가 발생했어요",
-                                buttonText = "닫기"
-                            ) {
-                                snackBarData.dismiss()
-                            }
-                        }
-                    }
-                }
+                MainContent(
+                    paddingValue = paddingValue,
+                    navigator = navigator,
+                    isConnected = isConnected,
+                    whiteSnackBarWithButtonHostState = whiteSnackBarWithButtonHostState,
+                )
             },
             bottomBar = {
                 MainBottomBar(
@@ -401,6 +197,224 @@ internal fun MainScreen(
                 }
             },
         )
+    }
+}
+
+@Composable
+private fun MainContent(
+    paddingValue: PaddingValues,
+    navigator: MainNavigator,
+    isConnected: Boolean,
+    whiteSnackBarWithButtonHostState: SnackbarHostState,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+    ) {
+        NavHost(
+            navController = navigator.navController,
+            startDestination = navigator.startDestination,
+            enterTransition = { EnterTransition.None },
+            exitTransition = { ExitTransition.None },
+            popEnterTransition = { EnterTransition.None },
+            popExitTransition = { ExitTransition.None }
+        ) {
+            splashNavGraph(
+                navigateToHome = {
+                    val navOptions = navOptions {
+                        popUpTo(navigator.navController.graph.findStartDestination().id) {
+                            inclusive = true
+                        }
+                        launchSingleTop = true
+                    }
+                    navigator.navigateToHome(navOptions = navOptions)
+                },
+                navigateToLogIn = {
+                    val navOptions = navOptions {
+                        popUpTo(navigator.navController.graph.findStartDestination().id) {
+                            inclusive = true
+                        }
+                        launchSingleTop = true
+                    }
+                    navigator.navigateToLogin(
+                        navOptions = navOptions
+                    )
+                },
+            )
+            homeNavGraph(
+                paddingValues = paddingValue,
+                navigateStoreDetail = navigator::navigateToStoreDetail,
+                navigateToUniversitySelection = navigator::navigateToUniversity,
+                navigateToAddNewJogbo = navigator::navigateToNewJogbo
+            )
+            reportNavGraph(
+                navigateReport = { latitude, longitude, location, address ->
+                    val navOptions = navOptions {
+                        popUpTo<Home> {
+                            inclusive = false
+                        }
+                        launchSingleTop = true
+                    }
+                    navigator.navigateToReport(
+                        LocationModel(
+                            latitude,
+                            longitude,
+                            location,
+                            address
+                        ), navOptions
+                    )
+                },
+                navigateToSearchStore = {
+                    navigator.navigateToSearchStore()
+                },
+                navigateUp = navigator::navigateUpIfNotHome,
+                navigateToReportFinish = { count, storeName, storeId ->
+                    val navOptions = navOptions {
+                        popUpTo<Home> {
+                            inclusive = false
+                        }
+                        launchSingleTop = true
+                    }
+                    navigator.navigateToReportFinish(
+                        count,
+                        storeName,
+                        storeId,
+                        navOptions
+                    )
+                },
+                navigateToHome = {
+                    val navOptions = navOptions {
+                        popUpTo<Home> {
+                            inclusive = false
+                        }
+                        launchSingleTop = true
+                    }
+                    navigator.navigateToHome(navOptions)
+                },
+                navigateToStoreDetail = { storeId ->
+                    navigator.navigateToStoreDetail(storeId)
+                },
+                navigateToAddNewJogbo = navigator::navigateToNewJogbo,
+            )
+            myNavGraph(
+                paddingValues = paddingValue,
+                navigateUp = navigator::navigateUpIfNotHome,
+                navigateToMyJogbo = navigator::navigateToMyJogbo,
+                navigateToMyStore = navigator::navigateToMyStore,
+                navigateToJogboDetail = navigator::navigateToMyJogboDetail,
+                navigateToNewJogbo = navigator::navigateToNewJogbo,
+                navigateToStoreDetail = navigator::navigateToStoreDetail,
+                navigateToHome = {
+                    val navOptions = navOptions {
+                        popUpTo<Home> {
+                            inclusive = false
+                        }
+                        launchSingleTop = true
+                    }
+                    navigator.navigateToHome(navOptions)
+                }
+            )
+            loginNavGraph(
+                navigateToHome = {
+                    val navOptions = navOptions {
+                        popUpTo<Login> {
+                            inclusive = true
+                        }
+                        launchSingleTop = true
+                    }
+                    navigator.navigateToHome(navOptions = navOptions)
+                },
+                navigateToOnboarding = {
+                    val navOptions = navOptions {
+                        popUpTo<Login> {
+                            inclusive = true
+                        }
+                        launchSingleTop = true
+                    }
+                    navigator.navigateToOnboarding(navOptions)
+                }
+            )
+
+            onboardingNavGraph(
+                navigateToUniversity = {
+                    val navOptions = navOptions {
+                        popUpTo<Onboarding> {
+                            inclusive = true
+                        }
+                        launchSingleTop = true
+                    }
+                    navigator.navigateToUniversity(navOptions)
+                }
+            )
+            universitySelectionNavGraph(
+                navigateToHome = {
+                    val navOptions = navOptions {
+                        popUpTo<UniversitySelection> {
+                            inclusive = true
+                        }
+                        launchSingleTop = true
+                    }
+                    navigator.navigateToHome(
+                        navOptions = navOptions
+                    )
+                }
+            )
+            storeDetailNavGraph(
+                navController = navigator.navController,
+                navigateUp = navigator::navigateUpIfNotHome,
+                navigateToAddNewJogbo = navigator::navigateToNewJogbo,
+                navigateToAddMenu = navigator::navigateToAddMenu,
+                navigateToEditMenu = navigator::navigateToEditMenu,
+                navigateToHome = {
+                    val navOptions = navOptions {
+                        popUpTo<Home> {
+                            inclusive = false
+                        }
+                        launchSingleTop = true
+                    }
+                    navigator.navigateToHome(navOptions)
+                }
+            )
+        }
+
+        if (!isConnected) {
+            SingleButtonDialog(
+                title = "네트워크 오류가 발생했어요",
+                description = "네트워크 연결 상태를 확인하고 다시 시도해주세요",
+                buttonTitle = "확인"
+            ) {
+                navigator.navigateUpIfNotHome()
+            }
+        }
+
+        SnackbarHost(
+            hostState = whiteSnackBarWithButtonHostState,
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .statusBarsPadding()
+                .padding(top = 35.dp)
+        ) { snackBarData ->
+            runCatching {
+                val (message, jogboId) = snackBarData.visuals.message.split("/")
+
+                HankkiWhiteSnackBarWithButton(
+                    message = message
+                ) {
+                    snackBarData.dismiss()
+
+                    navigator.navigateToMyJogboDetail(
+                        jogboId.toLong()
+                    )
+                }
+            }.onFailure {
+                HankkiWhiteSnackBarWithButton(
+                    message = "오류가 발생했어요",
+                    buttonText = "닫기"
+                ) {
+                    snackBarData.dismiss()
+                }
+            }
+        }
     }
 }
 

--- a/feature/main/src/main/java/com/hankki/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/hankki/feature/main/MainScreen.kt
@@ -233,8 +233,6 @@ internal fun MainScreen(
                                 navigator.navigateToStoreDetail(storeId)
                             },
                             navigateToAddNewJogbo = navigator::navigateToNewJogbo,
-                            onShowSnackBar = onShowWhiteSnackBarWithButton,
-                            onShowTextSnackBar = onShowErrorSnackBar
                         )
                         myNavGraph(
                             paddingValues = paddingValue,

--- a/feature/main/src/main/java/com/hankki/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/hankki/feature/main/MainScreen.kt
@@ -56,7 +56,7 @@ import com.hankki.core.designsystem.component.snackbar.HankkiTextSnackBar
 import com.hankki.core.designsystem.component.snackbar.HankkiTextSnackBarWithButton
 import com.hankki.core.designsystem.component.snackbar.HankkiWhiteSnackBarWithButton
 import com.hankki.core.designsystem.event.LocalSnackBarTrigger
-import com.hankki.core.designsystem.event.LocalSnackBarWithButtonTrigger
+import com.hankki.core.designsystem.event.LocalButtonSnackBarTrigger
 import com.hankki.core.designsystem.event.LocalWhiteSnackBarTrigger
 import com.hankki.core.designsystem.theme.Gray100
 import com.hankki.core.designsystem.theme.Gray400
@@ -142,7 +142,7 @@ internal fun MainScreen(
     CompositionLocalProvider(
         LocalSnackBarTrigger provides onShowErrorSnackBar,
         LocalWhiteSnackBarTrigger provides onShowWhiteSnackBarWithButton,
-        LocalSnackBarWithButtonTrigger provides onShowTextSnackBarWithButton,
+        LocalButtonSnackBarTrigger provides onShowTextSnackBarWithButton,
     ) {
         Scaffold(
             content = { paddingValue ->

--- a/feature/report/src/main/java/com/hankki/feature/report/finish/ReportFinishRoute.kt
+++ b/feature/report/src/main/java/com/hankki/feature/report/finish/ReportFinishRoute.kt
@@ -33,6 +33,8 @@ import com.hankki.core.designsystem.component.bottomsheet.HankkiStoreJogboBottom
 import com.hankki.core.designsystem.component.bottomsheet.JogboResponseModel
 import com.hankki.core.designsystem.component.button.HankkiButton
 import com.hankki.core.designsystem.component.button.HankkiTextButton
+import com.hankki.core.designsystem.event.LocalSnackBarWithButtonTrigger
+import com.hankki.core.designsystem.event.LocalWhiteSnackBarTrigger
 import com.hankki.core.designsystem.theme.Gray50
 import com.hankki.core.designsystem.theme.Gray500
 import com.hankki.core.designsystem.theme.Gray900
@@ -51,11 +53,11 @@ fun ReportFinishRoute(
     navigateToHome: () -> Unit,
     navigateToStoreDetail: (storeId: Long) -> Unit,
     navigateToAddNewJogbo: () -> Unit,
-    onShowSnackBar: (String, Long) -> Unit,
     viewModel: ReportFinishViewModel = hiltViewModel(),
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val whiteSnackBar = LocalWhiteSnackBarTrigger.current
 
     LaunchedEffect(key1 = true) {
         viewModel.setStoreInfo(
@@ -73,7 +75,7 @@ fun ReportFinishRoute(
                 )
 
                 is ReportFinishSideEffect.NavigateToHome -> navigateToHome()
-                is ReportFinishSideEffect.ShowSnackBar -> onShowSnackBar(
+                is ReportFinishSideEffect.ShowSnackBar -> whiteSnackBar(
                     sideEffect.message,
                     sideEffect.jogboId
                 )

--- a/feature/report/src/main/java/com/hankki/feature/report/finish/ReportFinishRoute.kt
+++ b/feature/report/src/main/java/com/hankki/feature/report/finish/ReportFinishRoute.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
@@ -33,7 +32,6 @@ import com.hankki.core.designsystem.component.bottomsheet.HankkiStoreJogboBottom
 import com.hankki.core.designsystem.component.bottomsheet.JogboResponseModel
 import com.hankki.core.designsystem.component.button.HankkiButton
 import com.hankki.core.designsystem.component.button.HankkiTextButton
-import com.hankki.core.designsystem.event.LocalSnackBarWithButtonTrigger
 import com.hankki.core.designsystem.event.LocalWhiteSnackBarTrigger
 import com.hankki.core.designsystem.theme.Gray50
 import com.hankki.core.designsystem.theme.Gray500

--- a/feature/report/src/main/java/com/hankki/feature/report/main/ReportRoute.kt
+++ b/feature/report/src/main/java/com/hankki/feature/report/main/ReportRoute.kt
@@ -61,6 +61,7 @@ import com.hankki.core.designsystem.component.layout.BottomBlurLayout
 import com.hankki.core.designsystem.component.textfield.HankkiMenuTextField
 import com.hankki.core.designsystem.component.textfield.HankkiPriceTextField
 import com.hankki.core.designsystem.component.topappbar.HankkiTopBar
+import com.hankki.core.designsystem.event.LocalSnackBarTrigger
 import com.hankki.core.designsystem.theme.Gray100
 import com.hankki.core.designsystem.theme.Gray300
 import com.hankki.core.designsystem.theme.Gray400
@@ -82,7 +83,6 @@ import kotlinx.coroutines.launch
 @Composable
 fun ReportRoute(
     location: LocationModel,
-    onShowTextSnackBar: (String) -> Unit,
     navigateUp: () -> Unit,
     navigateSearchStore: () -> Unit,
     navigateToReportFinish: (
@@ -95,6 +95,7 @@ fun ReportRoute(
     val tracker = LocalTracker.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val snackBar = LocalSnackBarTrigger.current
 
     val pickMedia =
         rememberLauncherForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
@@ -127,7 +128,7 @@ fun ReportRoute(
                 }
 
                 ReportSideEffect.UniversityError -> navigateUp()
-                ReportSideEffect.ReportError -> onShowTextSnackBar("오류가 발생했어요. 다시 시도해주세요")
+                ReportSideEffect.ReportError -> snackBar("오류가 발생했어요. 다시 시도해주세요")
             }
         }
     }

--- a/feature/report/src/main/java/com/hankki/feature/report/navigation/ReportNavigation.kt
+++ b/feature/report/src/main/java/com/hankki/feature/report/navigation/ReportNavigation.kt
@@ -67,8 +67,6 @@ fun NavGraphBuilder.reportNavGraph(
     navigateToStoreDetail: (storeId: Long) -> Unit,
     navigateToHome: () -> Unit,
     navigateToAddNewJogbo: () -> Unit,
-    onShowSnackBar: (String, Long) -> Unit,
-    onShowTextSnackBar: (String) -> Unit,
 ) {
     composable<Report> { backStackEntry ->
         val items = backStackEntry.toRoute<Report>()
@@ -79,7 +77,6 @@ fun NavGraphBuilder.reportNavGraph(
                 items.location,
                 items.address
             ),
-            onShowTextSnackBar = onShowTextSnackBar,
             navigateSearchStore = navigateToSearchStore,
             navigateUp = navigateUp,
             navigateToReportFinish = navigateToReportFinish,
@@ -103,7 +100,6 @@ fun NavGraphBuilder.reportNavGraph(
             navigateToHome = navigateToHome,
             navigateToStoreDetail = navigateToStoreDetail,
             navigateToAddNewJogbo = navigateToAddNewJogbo,
-            onShowSnackBar = onShowSnackBar
         )
     }
 }

--- a/feature/storedetail/src/main/java/com/hankki/feature/storedetail/StoreDetailRoute.kt
+++ b/feature/storedetail/src/main/java/com/hankki/feature/storedetail/StoreDetailRoute.kt
@@ -50,7 +50,7 @@ import com.hankki.core.designsystem.component.dialog.ImageDoubleButtonDialog
 import com.hankki.core.designsystem.component.layout.HankkiLoadingScreen
 import com.hankki.core.designsystem.component.topappbar.HankkiTopBar
 import com.hankki.core.designsystem.event.LocalSnackBarTrigger
-import com.hankki.core.designsystem.event.LocalSnackBarWithButtonTrigger
+import com.hankki.core.designsystem.event.LocalButtonSnackBarTrigger
 import com.hankki.core.designsystem.theme.Gray400
 import com.hankki.core.designsystem.theme.Gray50
 import com.hankki.core.designsystem.theme.Gray500
@@ -74,7 +74,7 @@ fun StoreDetailRoute(
 ) {
     val tracker = LocalTracker.current
     val snackBar = LocalSnackBarTrigger.current
-    val buttonSnackBar = LocalSnackBarWithButtonTrigger.current
+    val buttonSnackBar = LocalButtonSnackBarTrigger.current
 
     val storeState by viewModel.storeState.collectAsStateWithLifecycle()
     val dialogState by viewModel.dialogState.collectAsStateWithLifecycle()

--- a/feature/storedetail/src/main/java/com/hankki/feature/storedetail/StoreDetailRoute.kt
+++ b/feature/storedetail/src/main/java/com/hankki/feature/storedetail/StoreDetailRoute.kt
@@ -49,6 +49,8 @@ import com.hankki.core.designsystem.component.dialog.DoubleButtonDialog
 import com.hankki.core.designsystem.component.dialog.ImageDoubleButtonDialog
 import com.hankki.core.designsystem.component.layout.HankkiLoadingScreen
 import com.hankki.core.designsystem.component.topappbar.HankkiTopBar
+import com.hankki.core.designsystem.event.LocalSnackBarTrigger
+import com.hankki.core.designsystem.event.LocalSnackBarWithButtonTrigger
 import com.hankki.core.designsystem.theme.Gray400
 import com.hankki.core.designsystem.theme.Gray50
 import com.hankki.core.designsystem.theme.Gray500
@@ -66,13 +68,13 @@ fun StoreDetailRoute(
     storeId: Long,
     navigateUp: () -> Unit,
     navigateToAddNewJogbo: () -> Unit,
-    onShowSnackBar: (String, Long) -> Unit,
-    onShowErrorSnackBar: (String) -> Unit,
     viewModel: StoreDetailViewModel = hiltViewModel(),
     onAddMenuClick: (Long) -> Unit,
     onEditMenuClick: (Long) -> Unit
 ) {
     val tracker = LocalTracker.current
+    val snackBar = LocalSnackBarTrigger.current
+    val buttonSnackBar = LocalSnackBarWithButtonTrigger.current
 
     val storeState by viewModel.storeState.collectAsStateWithLifecycle()
     val dialogState by viewModel.dialogState.collectAsStateWithLifecycle()
@@ -91,7 +93,7 @@ fun StoreDetailRoute(
                 StoreDetailSideEffect.NavigateUp -> navigateUp()
                 StoreDetailSideEffect.NavigateToAddNewJogbo -> navigateToAddNewJogbo()
                 StoreDetailSideEffect.ShowTextSnackBar -> {
-                    onShowErrorSnackBar("이미 삭제된 식당입니다 ")
+                    snackBar("이미 삭제된 식당입니다 ")
                     navigateUp()
                 }
             }
@@ -142,7 +144,7 @@ fun StoreDetailRoute(
                 selectedIndex = storeState.selectedIndex,
                 buttonLabels = storeState.buttonLabels,
                 onNavigateUp = navigateUp,
-                onShowSnackBar = onShowSnackBar,
+                onShowSnackBar = buttonSnackBar,
                 onLikeClicked = {
                     viewModel.toggleLike(storeId)
                     tracker.track(

--- a/feature/storedetail/src/main/java/com/hankki/feature/storedetail/editbottomsheet/add/addmenu/AddMenuRoute.kt
+++ b/feature/storedetail/src/main/java/com/hankki/feature/storedetail/editbottomsheet/add/addmenu/AddMenuRoute.kt
@@ -23,6 +23,7 @@ import com.hankki.core.designsystem.component.button.HankkiButton
 import com.hankki.core.designsystem.component.textfield.HankkiMenuTextField
 import com.hankki.core.designsystem.component.textfield.HankkiPriceTextField
 import com.hankki.core.designsystem.component.topappbar.HankkiTopBar
+import com.hankki.core.designsystem.event.LocalSnackBarTrigger
 import com.hankki.core.designsystem.theme.*
 import kotlinx.collections.immutable.PersistentList
 
@@ -31,9 +32,9 @@ fun AddMenuRoute(
     storeId: Long,
     onNavigateUp: () -> Unit,
     onNavigateToSuccess: (Int) -> Unit,
-    onShowErrorSnackBar: (String) -> Unit,
     viewModel: AddMenuViewModel = hiltViewModel()
 ) {
+    val snackBar = LocalSnackBarTrigger.current
     val state by viewModel.addMenuState.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
@@ -46,7 +47,7 @@ fun AddMenuRoute(
                 AddMenuSideEffect.NavigateToSuccess -> onNavigateToSuccess(state.menuList.size)
                 AddMenuSideEffect.NavigateBack -> onNavigateUp()
                 is AddMenuSideEffect.ShowError -> {
-                    onShowErrorSnackBar(sideEffect.message)
+                    snackBar(sideEffect.message)
                 }
             }
         }

--- a/feature/storedetail/src/main/java/com/hankki/feature/storedetail/editbottomsheet/edit/delete/DeleteSuccessLastRoute.kt
+++ b/feature/storedetail/src/main/java/com/hankki/feature/storedetail/editbottomsheet/edit/delete/DeleteSuccessLastRoute.kt
@@ -21,6 +21,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hankki.core.designsystem.component.button.HankkiMediumButton
 import com.hankki.core.designsystem.component.topappbar.HankkiTopBar
+import com.hankki.core.designsystem.event.LocalSnackBarTrigger
 import com.hankki.core.designsystem.theme.Gray850
 import com.hankki.core.designsystem.theme.HankkiTheme
 import com.hankki.feature.storedetail.R
@@ -29,8 +30,9 @@ import com.hankki.feature.storedetail.R
 fun DeleteSuccessLastRoute(
     viewModel: DeleteSuccessViewModel = hiltViewModel(),
     onNavigateToHome: () -> Unit,
-    onShowErrorSnackBar: (String) -> Unit,
 ) {
+    val snackBar = LocalSnackBarTrigger.current
+
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val sideEffectFlow = viewModel.sideEffect
 
@@ -39,7 +41,7 @@ fun DeleteSuccessLastRoute(
             when (sideEffect) {
                 DeleteSuccessSideEffect.NavigateToStoreDetail -> onNavigateToHome()
                 is DeleteSuccessSideEffect.ShowError -> {
-                    onShowErrorSnackBar(sideEffect.message)
+                    snackBar(sideEffect.message)
                 }
                 else -> {}
             }

--- a/feature/storedetail/src/main/java/com/hankki/feature/storedetail/editbottomsheet/edit/delete/DeleteSuccessRoute.kt
+++ b/feature/storedetail/src/main/java/com/hankki/feature/storedetail/editbottomsheet/edit/delete/DeleteSuccessRoute.kt
@@ -21,6 +21,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hankki.core.designsystem.component.button.HankkiMediumButton
 import com.hankki.core.designsystem.component.topappbar.HankkiTopBar
+import com.hankki.core.designsystem.event.LocalSnackBarTrigger
 import com.hankki.core.designsystem.theme.Gray850
 import com.hankki.core.designsystem.theme.HankkiTheme
 import com.hankki.core.designsystem.theme.Red500
@@ -32,8 +33,9 @@ fun DeleteSuccessRoute(
     viewModel: DeleteSuccessViewModel = hiltViewModel(),
     onNavigateToEditMenu: () -> Unit,
     onNavigateToStoreDetailRoute: () -> Unit,
-    onShowErrorSnackBar: (String) -> Unit,
 ) {
+    val snackBar = LocalSnackBarTrigger.current
+
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val sideEffectFlow = viewModel.sideEffect
 
@@ -43,7 +45,7 @@ fun DeleteSuccessRoute(
                 DeleteSuccessSideEffect.NavigateToEditMenu -> onNavigateToEditMenu()
                 DeleteSuccessSideEffect.NavigateToStoreDetail -> onNavigateToStoreDetailRoute()
                 is DeleteSuccessSideEffect.ShowError -> {
-                    onShowErrorSnackBar(sideEffect.message)
+                    snackBar(sideEffect.message)
                 }
             }
         }

--- a/feature/storedetail/src/main/java/com/hankki/feature/storedetail/editbottomsheet/edit/editmenu/EditMenuRoute.kt
+++ b/feature/storedetail/src/main/java/com/hankki/feature/storedetail/editbottomsheet/edit/editmenu/EditMenuRoute.kt
@@ -32,6 +32,7 @@ import com.hankki.core.designsystem.component.layout.BottomBlurLayout
 import com.hankki.core.designsystem.component.layout.HankkiLoadingScreen
 import com.hankki.core.designsystem.component.layout.TopBlurLayout
 import com.hankki.core.designsystem.component.topappbar.HankkiTopBar
+import com.hankki.core.designsystem.event.LocalSnackBarTrigger
 import com.hankki.core.designsystem.theme.Gray700
 import com.hankki.core.designsystem.theme.Gray900
 import com.hankki.core.designsystem.theme.HankkiTheme
@@ -50,8 +51,8 @@ fun EditMenuRoute(
     onNavigateUp: () -> Unit,
     onNavigateToDeleteSuccess: (Long) -> Unit,
     onNavigateToDeleteSuccessLast: (Long) -> Unit,
-    onShowErrorSnackBar: (String) -> Unit,
 ) {
+    val snackBar = LocalSnackBarTrigger.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val dialogState by viewModel.dialogState.collectAsStateWithLifecycle()
 
@@ -72,7 +73,7 @@ fun EditMenuRoute(
                 }
                 is EditMenuSideEffect.NavigateBack -> onNavigateUp()
                 is EditMenuSideEffect.ShowSnackbar -> {
-                    onShowErrorSnackBar(sideEffect.message)
+                    snackBar(sideEffect.message)
                 }
             }
         }

--- a/feature/storedetail/src/main/java/com/hankki/feature/storedetail/editbottomsheet/edit/mod/ModRoute.kt
+++ b/feature/storedetail/src/main/java/com/hankki/feature/storedetail/editbottomsheet/edit/mod/ModRoute.kt
@@ -34,6 +34,7 @@ import com.hankki.core.designsystem.component.button.HankkiExpandedButton
 import com.hankki.core.designsystem.component.button.HankkiMediumButton
 import com.hankki.core.designsystem.component.dialog.DoubleButtonDialog
 import com.hankki.core.designsystem.component.topappbar.HankkiTopBar
+import com.hankki.core.designsystem.event.LocalSnackBarTrigger
 import com.hankki.core.designsystem.theme.Gray400
 import com.hankki.core.designsystem.theme.Gray700
 import com.hankki.core.designsystem.theme.Gray900
@@ -57,8 +58,9 @@ fun ModRoute(
     onNavigateUp: () -> Unit,
     onNavigateToEditSuccess: (Long) -> Unit,
     onNavigateToDeleteSuccess: (Long) -> Unit,
-    onShowErrorSnackBar: (String) -> Unit,
 ) {
+    val snackBar = LocalSnackBarTrigger.current
+
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val sideEffectFlow = viewModel.sideEffect
     val coroutineScope = rememberCoroutineScope()
@@ -75,7 +77,7 @@ fun ModRoute(
                 is ModSideEffect.NavigateToDeleteSuccess -> onNavigateToDeleteSuccess(sideEffect.storeId)
                 ModSideEffect.NavigateUp -> onNavigateUp()
                 is ModSideEffect.ShowSnackbar -> {
-                    onShowErrorSnackBar(sideEffect.message)
+                    snackBar(sideEffect.message)
                 }
             }
         }
@@ -151,7 +153,7 @@ fun ModifyMenuScreen(
     onSubmit: () -> Unit,
     onShowDeleteDialog: () -> Unit,
     onShowModCompleteDialog: () -> Unit,
-    hidePriceWarning: () -> Unit
+    hidePriceWarning: () -> Unit,
 ) {
     val focusManager = LocalFocusManager.current
     val isVisibleIme = WindowInsets.isImeVisible

--- a/feature/storedetail/src/main/java/com/hankki/feature/storedetail/navigation/navigateStoreDetail.kt
+++ b/feature/storedetail/src/main/java/com/hankki/feature/storedetail/navigation/navigateStoreDetail.kt
@@ -63,8 +63,6 @@ fun NavGraphBuilder.storeDetailNavGraph(
     navController: NavController,
     navigateUp: () -> Unit,
     navigateToAddNewJogbo: () -> Unit,
-    onShowSnackBar: (String, Long) -> Unit,
-    onShowErrorSnackBar: (String) -> Unit,
     navigateToAddMenu: (Long) -> Unit,
     navigateToEditMenu: (Long) -> Unit,
     navigateToHome: () -> Unit
@@ -75,8 +73,6 @@ fun NavGraphBuilder.storeDetailNavGraph(
             storeId = items.storeId,
             navigateUp = navigateUp,
             navigateToAddNewJogbo = navigateToAddNewJogbo,
-            onShowSnackBar = onShowSnackBar,
-            onShowErrorSnackBar = onShowErrorSnackBar,
             onAddMenuClick = { navigateToAddMenu(items.storeId) },
             onEditMenuClick = { navigateToEditMenu(items.storeId) }
         )
@@ -95,8 +91,7 @@ fun NavGraphBuilder.storeDetailNavGraph(
                         popUpTo(StoreDetail(items.storeId)) { inclusive = false }
                     }
                 )
-            },
-            onShowErrorSnackBar = onShowErrorSnackBar,
+            }
         )
     }
 
@@ -123,8 +118,7 @@ fun NavGraphBuilder.storeDetailNavGraph(
                 navController.navigateDeleteSuccessLast(successStoreId, navOptions {
                     popUpTo(StoreDetail(successStoreId)) { inclusive = false }
                 })
-            },
-            onShowErrorSnackBar = onShowErrorSnackBar,
+            }
         )
     }
 
@@ -150,7 +144,6 @@ fun NavGraphBuilder.storeDetailNavGraph(
                     popUpTo(StoreDetail(successStoreId)) { inclusive = false }
                 })
             },
-            onShowErrorSnackBar = onShowErrorSnackBar,
         )
     }
 
@@ -183,14 +176,12 @@ fun NavGraphBuilder.storeDetailNavGraph(
                     popUpTo(StoreDetail(items.storeId)) { inclusive = false }
                 })
             },
-            onShowErrorSnackBar = onShowErrorSnackBar,
         )
     }
 
     composable<DeleteSuccessLast> {
         DeleteSuccessLastRoute(
-            onNavigateToHome = navigateToHome,
-            onShowErrorSnackBar = onShowErrorSnackBar
+            onNavigateToHome = navigateToHome
         )
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -179,6 +179,7 @@ androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profi
 
 [bundles]
 okhttp = ["okhttp", "okhttp-logging"]
+retrofit = ["retrofit-core", "retrofit-kotlin-serialization"]
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }


### PR DESCRIPTION
## *📌 Issue*
- closed #270

## *⛳️ Work Description*
- Lambda를 매개변수로 넘겨줘 SnackBar를 호출시키는 방식에서 CompositionLocalProvider를 사용하는 방식으로 변경
- prop drilling 문제 해결
- dependencies 최적화
- Main Screen 과하게 무거운 content 분리

## *📸 Screenshot*
변경없음.


## *📢 To Reviewers*
- 아래처럼 각 Route에서 만들어서 사용하시면 됩니다.
- 기존 코드는 제가 수정만 사삭 했습니다
- 수정하는 과정에서 보니까 SideEffect 없이 바로 호출하는 코드들이 일부 있더라구요. 시간나면 수정해주세요~ @0se0 
- [Composition Local에 대한 간단한 아티클](https://naemamdaelo.tistory.com/entry/Android-Jetpack-Comopse%EC%9D%98-CompositionLocal%EC%9D%84-%EC%9D%B4%ED%95%B4%ED%95%98%EA%B3%A0-%EC%8D%A8%EB%B3%B4%EC%9E%90)

```
val snackBar = LocalSnackBarTrigger.current

snackBar(errorMessage)
```
