### PR TITLE
[Feature/#272] 토큰 재발급 후 기존 통신시 400에러 해결

### DIFF
--- a/core/network/src/main/java/com/hankki/core/network/NetworkModule.kt
+++ b/core/network/src/main/java/com/hankki/core/network/NetworkModule.kt
@@ -66,7 +66,7 @@ internal object NetworkModule {
     @JWT
     fun provideJWTOkHttpClient(
         loggingInterceptor: Interceptor,
-        @JWT oauthInterceptor: Interceptor
+        @JWT oauthInterceptor: Interceptor,
     ): OkHttpClient = OkHttpClient.Builder()
         .addInterceptor(loggingInterceptor)
         .addInterceptor(oauthInterceptor)

--- a/feature/home/src/main/java/com/hankki/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/hankki/feature/home/HomeViewModel.kt
@@ -3,7 +3,6 @@ package com.hankki.feature.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hankki.core.common.utill.EmptyUiState
-import com.hankki.core.designsystem.R
 import com.hankki.core.designsystem.component.bottomsheet.JogboResponseModel
 import com.hankki.domain.home.entity.response.CategoriesEntity
 import com.hankki.domain.home.entity.response.CategoryEntity


### PR DESCRIPTION
## *📌 Issue*
- closed #272 

## *⛳️ Work Description*
- 토큰 재발급 후 기존 통신시 400에러가 발생하는 현상 확인 및 해결
- 기존 requestd의 헤더를 제거하지 않고 새 헤더를 추가하는 코드를 발견하여 기존 헤더는 제거하도록 했습니다!
- 추가적으로 기존 코드에서 suspend가 타고 올라가는 현상 발견하여 아래로 내렸습니다. -> 불필요하게 runBlocking을 사용하고 있어서 꼭 필요한 곳으로 옮겼어요

```
getUniversityInformation: J1.y: HTTP 400 Bad Request
2024-12-10 13:08:08.941  9615-9615  HomeViewMo...nformation com.hankki.hankkijogbo               E  J1.y: HTTP 400 Bad Request (Ask Gemini)
                                                                                                    	at J1.F.onResponse(Unknown Source:187)
                                                                                                    	at J1.H.onResponse(Unknown Source:8)
                                                                                                    	at r1.f.run(Unknown Source:54)
                                                                                                    	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
                                                                                                    	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644)
                                                                                                    	at java.lang.Thread.run(Thread.java:1012)
```

## *📸 Screenshot*
- 업소용~

## *📢 To Reviewers*
- 발견할 수 있는 오류였는데 이제서야 발견했던거라 아쉽네용
- 충분히 할 수 있는 실수였으니까 괜찮구 담번엔 더 꼼꼼하게 코드 짜기!
- 저두 앞으로 코드리뷰 좀 더 꼼꼼하게 하겠습니다~!!
