### PR TITLE
[Feature/#294] 제보화면에서 텍스트박스를 키보드가 가리는 현상을 해결합니다.

### DIFF
--- a/core/common/src/main/java/com/hankki/core/common/extension/Modifier.kt
+++ b/core/common/src/main/java/com/hankki/core/common/extension/Modifier.kt
@@ -7,13 +7,9 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.consumeWindowInsets
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -30,13 +26,10 @@ import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.findRootCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
-import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 
 inline fun Modifier.noRippleClickable(
@@ -137,15 +130,18 @@ fun Modifier.ignoreNextModifiers(): Modifier {
 
 fun Modifier.animateScrollAroundItem(
     scrollState: ScrollState,
-    yPosition: Float = 50f,
 ): Modifier = composed {
     var scrollToPosition by remember {
         mutableFloatStateOf(0f)
     }
     val coroutineScope = rememberCoroutineScope()
+
     this
         .onGloballyPositioned { coordinates ->
-            scrollToPosition = coordinates.positionInParent().y + yPosition
+            val itemTop = coordinates.positionInParent().y
+            val itemHeight = coordinates.size.height
+
+            scrollToPosition = itemTop + itemHeight
         }
         .onFocusEvent {
             if (it.isFocused) {
@@ -154,17 +150,4 @@ fun Modifier.animateScrollAroundItem(
                 }
             }
         }
-}
-
-fun Modifier.advancedImePadding() = composed {
-    var consumePadding by remember { mutableIntStateOf(0) }
-
-    onGloballyPositioned { coordinates ->
-        val rootCoordinate = coordinates.findRootCoordinates()
-        val bottom = coordinates.positionInWindow().y + coordinates.size.height
-
-        consumePadding = (rootCoordinate.size.height - bottom).toInt()
-    }
-        .consumeWindowInsets(PaddingValues(bottom = (consumePadding / LocalDensity.current.density).dp))
-        .imePadding()
 }

--- a/core/common/src/main/java/com/hankki/core/common/extension/Modifier.kt
+++ b/core/common/src/main/java/com/hankki/core/common/extension/Modifier.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
-import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import kotlinx.coroutines.launch

--- a/core/common/src/main/java/com/hankki/core/common/extension/Modifier.kt
+++ b/core/common/src/main/java/com/hankki/core/common/extension/Modifier.kt
@@ -7,9 +7,13 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -26,10 +30,13 @@ import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.findRootCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 
 inline fun Modifier.noRippleClickable(
@@ -147,4 +154,17 @@ fun Modifier.animateScrollAroundItem(
                 }
             }
         }
+}
+
+fun Modifier.advancedImePadding() = composed {
+    var consumePadding by remember { mutableIntStateOf(0) }
+
+    onGloballyPositioned { coordinates ->
+        val rootCoordinate = coordinates.findRootCoordinates()
+        val bottom = coordinates.positionInWindow().y + coordinates.size.height
+
+        consumePadding = (rootCoordinate.size.height - bottom).toInt()
+    }
+        .consumeWindowInsets(PaddingValues(bottom = (consumePadding / LocalDensity.current.density).dp))
+        .imePadding()
 }

--- a/core/common/src/main/java/com/hankki/core/common/extension/Modifier.kt
+++ b/core/common/src/main/java/com/hankki/core/common/extension/Modifier.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import kotlinx.coroutines.launch
@@ -130,6 +131,7 @@ fun Modifier.ignoreNextModifiers(): Modifier {
 
 fun Modifier.animateScrollAroundItem(
     scrollState: ScrollState,
+    verticalWeight: Int = 0
 ): Modifier = composed {
     var scrollToPosition by remember {
         mutableFloatStateOf(0f)
@@ -141,7 +143,7 @@ fun Modifier.animateScrollAroundItem(
             val itemTop = coordinates.positionInParent().y
             val itemHeight = coordinates.size.height
 
-            scrollToPosition = itemTop + itemHeight
+            scrollToPosition = itemTop + itemHeight + verticalWeight
         }
         .onFocusEvent {
             if (it.isFocused) {

--- a/feature/report/src/main/java/com/hankki/feature/report/main/ReportRoute.kt
+++ b/feature/report/src/main/java/com/hankki/feature/report/main/ReportRoute.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -48,7 +49,6 @@ import androidx.lifecycle.flowWithLifecycle
 import com.hankki.core.common.amplitude.EventType
 import com.hankki.core.common.amplitude.LocalTracker
 import com.hankki.core.common.extension.addFocusCleaner
-import com.hankki.core.common.extension.advancedImePadding
 import com.hankki.core.common.extension.animateScrollAroundItem
 import com.hankki.core.common.extension.noRippleClickable
 import com.hankki.core.designsystem.R
@@ -237,7 +237,7 @@ fun ReportScreen(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .advancedImePadding()
+                    .imePadding()
                     .verticalScroll(scrollState),
             ) {
                 Spacer(modifier = Modifier.height(18.dp))

--- a/feature/report/src/main/java/com/hankki/feature/report/main/ReportRoute.kt
+++ b/feature/report/src/main/java/com/hankki/feature/report/main/ReportRoute.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -49,6 +48,7 @@ import androidx.lifecycle.flowWithLifecycle
 import com.hankki.core.common.amplitude.EventType
 import com.hankki.core.common.amplitude.LocalTracker
 import com.hankki.core.common.extension.addFocusCleaner
+import com.hankki.core.common.extension.advancedImePadding
 import com.hankki.core.common.extension.animateScrollAroundItem
 import com.hankki.core.common.extension.noRippleClickable
 import com.hankki.core.designsystem.R
@@ -237,6 +237,7 @@ fun ReportScreen(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
+                    .advancedImePadding()
                     .verticalScroll(scrollState),
             ) {
                 Spacer(modifier = Modifier.height(18.dp))
@@ -258,7 +259,6 @@ fun ReportScreen(
                     modifier = Modifier
                         .padding(horizontal = 22.dp)
                         .fillMaxWidth()
-                        .imePadding()
                 ) {
                     StoreCategoryChips(
                         title = stringResource(id = com.hankki.feature.report.R.string.show_store_categories),

--- a/feature/report/src/main/java/com/hankki/feature/report/main/ReportRoute.kt
+++ b/feature/report/src/main/java/com/hankki/feature/report/main/ReportRoute.kt
@@ -32,11 +32,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -302,6 +306,7 @@ fun ReportScreen(
                             Spacer(modifier = Modifier.height(24.dp))
                         }
 
+                        var addMenuButtonSize by remember { mutableIntStateOf(0) }
                         menuList.forEachIndexed { index, menu ->
                             MenuWithPriceInputComponent(
                                 name = menu.name,
@@ -315,7 +320,10 @@ fun ReportScreen(
                                     changePrice(index, price)
                                 },
                                 deleteMenu = { deleteMenu(index) },
-                                modifier = Modifier.animateScrollAroundItem(scrollState)
+                                modifier = Modifier.animateScrollAroundItem(
+                                    scrollState = scrollState,
+                                    verticalWeight = addMenuButtonSize
+                                )
                             )
                             if (index != menuList.lastIndex) {
                                 Spacer(modifier = Modifier.height(16.dp))
@@ -323,18 +331,23 @@ fun ReportScreen(
                         }
 
                         Spacer(modifier = Modifier.height(24.dp))
-                        AddMenuButton(onClick = {
-                            addMenu()
-                            coroutineScope.launch {
-                                delay(100)
+                        AddMenuButton(
+                            onClick = {
+                                addMenu()
+                                coroutineScope.launch {
+                                    delay(100)
 
-                                if (isVisibleIme) {
-                                    focusManager.moveFocus(FocusDirection.Next)
-                                } else {
-                                    scrollState.animateScrollTo(scrollState.maxValue)
+                                    if (isVisibleIme) {
+                                        focusManager.moveFocus(FocusDirection.Next)
+                                    } else {
+                                        scrollState.animateScrollTo(scrollState.maxValue)
+                                    }
                                 }
+                            },
+                            modifier = Modifier.onGloballyPositioned {
+                                addMenuButtonSize = it.size.height
                             }
-                        })
+                        )
 
                         Spacer(modifier = Modifier.height(35.dp))
                         BottomBlurLayout()
@@ -497,9 +510,12 @@ fun MenuWithPriceInputComponent(
 }
 
 @Composable
-fun AddMenuButton(onClick: () -> Unit) {
+fun AddMenuButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     Row(
-        modifier = Modifier.noRippleClickable(onClick = onClick),
+        modifier = modifier.noRippleClickable(onClick = onClick),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Icon(


### PR DESCRIPTION
## *📌 Issue*
- closed #294 

## *⛳️ Work Description*
- 기존화면의 경우 키보드가 텍스트 박스를 가립니다
- `onGloballyPositioned`를 이용해 해당 아이템의 y position을 구하고, item의 height를 구해 position + height 높이만큼 카메라를 스크롤 시켜 해결했습니다.

## *📸 Screenshot*
Before | After
:--: | :--:
<video src="https://github.com/user-attachments/assets/d04d5d35-b974-4890-91a6-c82ab8a2b661" width="300" > | <video src="https://github.com/user-attachments/assets/ea700bd9-316b-4f93-a1d5-2968471df7f7" width="300" >




<!--꼭 수정 전 후 스크린샷을 넣어주세요!-->
<!--영상도 가능하다면 전 후 를 넣어주면 좋아요 :) -->

## *📢 To Reviewers*
- 오류 텍스트까지도 깔끔하게 잘 나오는데 영상에 안담아버렸네요
- 민재 코드 쇽샥해서 해결하려다가 작동 안돼서 결국 따로 구현해버렸어요 ㅜㅜ
- 화이팅~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated scroll animation behavior in the app.
	- Modified on-screen keyboard layout interaction in the report screen.
	- Enhanced layout responsiveness with new button size tracking.

- **Bug Fixes**
	- Refined scroll positioning mechanism.
	- Improved keyboard responsiveness in UI layout.
	- Restructured button click event handling for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->