### PR TITLE
[Feature/#298] url image를 구현합니다

### DIFF
--- a/core/designsystem/src/main/java/com/hankki/core/designsystem/component/item/UrlImage.kt
+++ b/core/designsystem/src/main/java/com/hankki/core/designsystem/component/item/UrlImage.kt
@@ -1,0 +1,47 @@
+package com.hankki.core.designsystem.component.item
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.hankki.core.designsystem.R
+
+@Composable
+fun UrlImage(
+    url: String,
+    modifier: Modifier = Modifier,
+    contentScale: ContentScale = ContentScale.Fit,
+    contentDescription: String? = null,
+) {
+    if (LocalInspectionMode.current) {
+        Image(
+            imageVector = ImageVector.vectorResource(R.drawable.img_fake_red),
+            contentDescription = contentDescription,
+            contentScale = contentScale,
+            modifier = modifier
+        )
+    } else {
+        AsyncImage(
+            model = url,
+            contentDescription = contentDescription,
+            contentScale = contentScale,
+            modifier = modifier
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun UrlImagePreview() {
+    UrlImage(
+        url = "",
+        modifier = Modifier.size(100.dp),
+    )
+}

--- a/core/designsystem/src/main/res/drawable/img_fake_red.xml
+++ b/core/designsystem/src/main/res/drawable/img_fake_red.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+    <path
+        android:pathData="M0,0h100v100h-100z"
+        android:fillColor="#FF3737"/>
+</vector>

--- a/feature/home/src/main/java/com/hankki/feature/home/component/HankkiCatetoryScrollableTabRow.kt
+++ b/feature/home/src/main/java/com/hankki/feature/home/component/HankkiCatetoryScrollableTabRow.kt
@@ -1,6 +1,5 @@
 package com.hankki.feature.home.component
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -34,21 +33,24 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.hankki.core.common.extension.noRippleClickable
+import com.hankki.core.designsystem.component.item.UrlImage
 import com.hankki.core.designsystem.theme.Gray900
 import com.hankki.core.designsystem.theme.HankkiTheme
+import com.hankki.core.designsystem.theme.HankkijogboTheme
 import com.hankki.core.designsystem.theme.White
 import com.hankki.feature.home.R
 import com.hankki.feature.home.model.CategoryChipItem
 import com.hankki.feature.home.model.HomeChips
 import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
 
 @Composable
 fun HankkiCategoryScrollableTabRow(
@@ -211,5 +213,68 @@ private fun FilterButton(
 
             Spacer(modifier = Modifier.padding(end = 12.dp))
         }
+    }
+}
+
+@Preview
+@Composable
+fun HankkiCategoryScrollableTabRowPreview() {
+    HankkijogboTheme {
+        HankkiCategoryScrollableTabRow(
+            categoryChipItems = listOf(
+                CategoryChipItem(
+                    name = "한식",
+                    imageUrl = "",
+                    tag = "korean"
+                ),
+                CategoryChipItem(
+                    name = "중식",
+                    imageUrl = "",
+                    tag = "chinese"
+                ),
+                CategoryChipItem(
+                    name = "일식",
+                    imageUrl = "",
+                    tag = "japanese"
+                ),
+                CategoryChipItem(
+                    name = "양식",
+                    imageUrl = "",
+                    tag = "western"
+                ),
+                CategoryChipItem(
+                    name = "분식",
+                    imageUrl = "",
+                    tag = "snack"
+                ),
+                CategoryChipItem(
+                    name = "카페",
+                    imageUrl = "",
+                    tag = "cafe"
+                ),
+                CategoryChipItem(
+                    name = "편의점",
+                    imageUrl = "",
+                    tag = "convenience"
+                ),
+                CategoryChipItem(
+                    name = "패스트푸드",
+                    imageUrl = "",
+                    tag = "fastfood"
+                ),
+                CategoryChipItem(
+                    name = "디저트",
+                    imageUrl = "",
+                    tag = "dessert"
+                ),
+                CategoryChipItem(
+                    name = "음료",
+                    imageUrl = "",
+                    tag = "drink"
+                ),
+            ).toPersistentList(),
+            onClickItem = { _, _, _ -> },
+            onClickFilterButton = { },
+        )
     }
 }

--- a/feature/home/src/main/java/com/hankki/feature/home/component/HankkiCatetoryScrollableTabRow.kt
+++ b/feature/home/src/main/java/com/hankki/feature/home/component/HankkiCatetoryScrollableTabRow.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
 import com.hankki.core.common.extension.noRippleClickable
 import com.hankki.core.designsystem.component.item.UrlImage
 import com.hankki.core.designsystem.theme.Gray900
@@ -110,8 +109,8 @@ fun HankkiCategoryScrollableTabRow(
                                 )
                             },
                         ) {
-                            AsyncImage(
-                                model = item.imageUrl,
+                            UrlImage(
+                                url = item.imageUrl,
                                 contentDescription = "filter",
                                 modifier = Modifier
                                     .padding(horizontal = 14.dp)


### PR DESCRIPTION
## *📌 Issue*
- closed #298 

## *⛳️ Work Description*
- UrlImage 구현
- 예시 적용

해당 issue를 진행하는 이유는 아래와 같습니다.

특정 라이브러리에 대한 과한 의존성 제거
현재 구조상 coil에서 glide로 변경하게 될 경우 모든 AsyncImage를 수정해야합니다. 그렇기에 UrlImage로 한번 wrapping하여 추후 라이브러리가 변경되더라도 코드 변경을 최소화 하고자 합니다.
preview에서 AsyncImage가 보이지 않는 현상을 개선합니다.
서버에서 이미지를 가져오는 AsyncImage의 특성상 Preview에서는 해당 영역 자체가 보이지 않습니다. 이를 개선하여 Preview에서의 불편함을 없앱니다. [(참고 링크)](https://naemamdaelo.tistory.com/entry/AsyncImage%EB%A5%BC-Preview%EC%97%90%EC%84%9C-%EB%B3%B4%EB%8A%94-3%EA%B0%80%EC%A7%80-%EB%B0%A9%EB%B2%95)


## *📸 Screenshot*
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/60dab0e2-4789-42e6-820d-5efea39c2196" width="300" />|<img src="https://github.com/user-attachments/assets/746006cd-e2e4-44b2-80f2-72720f60335f" width="300" />  


## *📢 To Reviewers*
- 아자자~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Launched an enhanced image display component that smartly loads images from remote sources while providing visual placeholders during inspection.
  - Upgraded the home category tab to utilize the new image rendering, ensuring a more consistent and engaging visual experience.
  - Introduced a new bold design asset to further enrich the app’s visual aesthetics.
  - Added a preview capability for both the image component and the home category tab for improved visual testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->