### PR TITLE
[Feature/#300] Attach Amplitude

### DIFF
--- a/core/common/src/main/java/com/hankki/core/common/amplitude/AmplitudeManager.kt
+++ b/core/common/src/main/java/com/hankki/core/common/amplitude/AmplitudeManager.kt
@@ -23,13 +23,14 @@ class AmplitudeTracker @Inject constructor(
         ),
     )
 
-    fun track(type: EventType, name: String, properties: Map<String, Any?> = emptyMap()) {
+    fun track(type: EventType, name: String, properties: Map<PropertyKey, Any?> = emptyMap()) {
+        val eventType = if (type == EventType.NONE) name else "${name}_${type.prefix}"
+        val properties = properties.mapKeys { it.key.key }
+
         if (BuildConfig.DEBUG) {
-            Timber.d("Amplitude: ${name}_${type.prefix} properties: $properties")
+            Timber.d("Amplitude: $eventType properties: $properties")
         }
-        amplitude.track(
-            eventType = if (type == EventType.NONE) name else "${name}_${type.prefix}",
-            eventProperties = properties
-        )
+
+        amplitude.track(eventType = eventType, eventProperties = properties)
     }
 }

--- a/core/common/src/main/java/com/hankki/core/common/amplitude/AmplitudeManager.kt
+++ b/core/common/src/main/java/com/hankki/core/common/amplitude/AmplitudeManager.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.compose.runtime.staticCompositionLocalOf
 import com.amplitude.android.Amplitude
 import com.amplitude.android.Configuration
-import com.amplitude.android.events.Identify
 import com.hankki.core.common.BuildConfig
 import dagger.hilt.android.qualifiers.ApplicationContext
 import timber.log.Timber
@@ -28,6 +27,9 @@ class AmplitudeTracker @Inject constructor(
         if (BuildConfig.DEBUG) {
             Timber.d("Amplitude: ${name}_${type.prefix} properties: $properties")
         }
-        amplitude.track(eventType = "${name}_${type.prefix}", eventProperties = properties)
+        amplitude.track(
+            eventType = if (type == EventType.NONE) name else "${name}_${type.prefix}",
+            eventProperties = properties
+        )
     }
 }

--- a/core/common/src/main/java/com/hankki/core/common/amplitude/EventType.kt
+++ b/core/common/src/main/java/com/hankki/core/common/amplitude/EventType.kt
@@ -4,5 +4,6 @@ enum class EventType(val prefix: String) {
     ADD("Add"),
     CLICK("Click"),
     CREATE("Create"),
-    COMPLETED("Completed")
+    COMPLETED("Completed"),
+    NONE("")
 }

--- a/core/common/src/main/java/com/hankki/core/common/amplitude/EventType.kt
+++ b/core/common/src/main/java/com/hankki/core/common/amplitude/EventType.kt
@@ -3,5 +3,6 @@ package com.hankki.core.common.amplitude
 enum class EventType(val prefix: String) {
     ADD("Add"),
     CLICK("Click"),
-    CREATE("Create")
+    CREATE("Create"),
+    COMPLETED("Completed")
 }

--- a/core/common/src/main/java/com/hankki/core/common/amplitude/PropertyKey.kt
+++ b/core/common/src/main/java/com/hankki/core/common/amplitude/PropertyKey.kt
@@ -1,0 +1,10 @@
+package com.hankki.core.common.amplitude
+
+enum class PropertyKey(val key: String) {
+    STORE("식당"),
+    FOOD("food"),
+    ARRAY("정렬"),
+    PRICE("가격대"),
+    JOGBO("족보"),
+    UNIVERSITY("university")
+}

--- a/feature/home/src/main/java/com/hankki/feature/home/HomeRoute.kt
+++ b/feature/home/src/main/java/com/hankki/feature/home/HomeRoute.kt
@@ -64,6 +64,7 @@ import androidx.lifecycle.flowWithLifecycle
 import com.google.android.gms.location.LocationServices
 import com.hankki.core.common.amplitude.EventType
 import com.hankki.core.common.amplitude.LocalTracker
+import com.hankki.core.common.amplitude.PropertyKey
 import com.hankki.core.common.extension.ignoreNextModifiers
 import com.hankki.core.common.extension.noRippleClickable
 import com.hankki.core.common.utill.EmptyUiState
@@ -463,7 +464,7 @@ fun HomeScreen(
                                     type = EventType.CLICK,
                                     name = "Home_Map_Pin",
                                     properties = mapOf(
-                                        "식당" to marker.name
+                                        PropertyKey.STORE to marker.name
                                     )
                                 )
                                 true
@@ -567,7 +568,7 @@ fun HomeScreen(
                                                         type = EventType.CLICK,
                                                         name = "Home_StoreCard",
                                                         properties = mapOf(
-                                                            "식당" to item.name
+                                                            PropertyKey.STORE to item.name
                                                         )
                                                     )
                                                 }

--- a/feature/home/src/main/java/com/hankki/feature/home/HomeRoute.kt
+++ b/feature/home/src/main/java/com/hankki/feature/home/HomeRoute.kt
@@ -567,7 +567,7 @@ fun HomeScreen(
                                                         type = EventType.CLICK,
                                                         name = "Home_StoreCard",
                                                         properties = mapOf(
-                                                            "식당 이름" to item.name
+                                                            "식당" to item.name
                                                         )
                                                     )
                                                 }

--- a/feature/home/src/main/java/com/hankki/feature/home/HomeRoute.kt
+++ b/feature/home/src/main/java/com/hankki/feature/home/HomeRoute.kt
@@ -556,6 +556,13 @@ fun HomeScreen(
                                                 heartCount = item.heartCount,
                                                 onClickItem = { id ->
                                                     navigateStoreDetail(id)
+                                                    tracker.track(
+                                                        type = EventType.CLICK,
+                                                        name = "Home_StoreCard",
+                                                        properties = mapOf(
+                                                            "식당 이름" to item.name
+                                                        )
+                                                    )
                                                 }
                                             ) {
                                                 selectStoreItem(item)

--- a/feature/home/src/main/java/com/hankki/feature/home/HomeRoute.kt
+++ b/feature/home/src/main/java/com/hankki/feature/home/HomeRoute.kt
@@ -459,6 +459,13 @@ fun HomeScreen(
                             captionText = if (cameraPositionState.position.zoom > CAN_SEE_TITLE_ZOOM) marker.name else "",
                             onClick = {
                                 clickMarkerItem(marker.id)
+                                tracker.track(
+                                    type = EventType.CLICK,
+                                    name = "Home_Map_Pin",
+                                    properties = mapOf(
+                                        "식당" to marker.name
+                                    )
+                                )
                                 true
                             }
                         )

--- a/feature/home/src/main/java/com/hankki/feature/home/component/HankkiCatetoryScrollableTabRow.kt
+++ b/feature/home/src/main/java/com/hankki/feature/home/component/HankkiCatetoryScrollableTabRow.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.hankki.core.common.amplitude.EventType
 import com.hankki.core.common.amplitude.LocalTracker
+import com.hankki.core.common.amplitude.PropertyKey
 import com.hankki.core.common.extension.noRippleClickable
 import com.hankki.core.designsystem.theme.Gray900
 import com.hankki.core.designsystem.theme.HankkiTheme
@@ -113,7 +114,7 @@ fun HankkiCategoryScrollableTabRow(
                                     type = EventType.CLICK,
                                     name = "Home_Food_Categories",
                                     properties = mapOf(
-                                        "food" to item.name
+                                        PropertyKey.FOOD to item.name
                                     )
                                 )
                             },

--- a/feature/home/src/main/java/com/hankki/feature/home/component/HankkiCatetoryScrollableTabRow.kt
+++ b/feature/home/src/main/java/com/hankki/feature/home/component/HankkiCatetoryScrollableTabRow.kt
@@ -41,6 +41,8 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import com.hankki.core.common.amplitude.EventType
+import com.hankki.core.common.amplitude.LocalTracker
 import com.hankki.core.common.extension.noRippleClickable
 import com.hankki.core.designsystem.theme.Gray900
 import com.hankki.core.designsystem.theme.HankkiTheme
@@ -58,6 +60,7 @@ fun HankkiCategoryScrollableTabRow(
     modifier: Modifier = Modifier,
     onClickFilterButton: () -> Unit,
 ) {
+    val tracker = LocalTracker.current
     val currentDensity = LocalDensity.current
 
     var selectedIndex by rememberSaveable { mutableIntStateOf(0) }
@@ -105,6 +108,13 @@ fun HankkiCategoryScrollableTabRow(
                                     HomeChips.CATEGORY,
                                     item.name,
                                     item.tag
+                                )
+                                tracker.track(
+                                    type = EventType.CLICK,
+                                    name = "Home_Food_Categories",
+                                    properties = mapOf(
+                                        "food" to item.name
+                                    )
                                 )
                             },
                         ) {

--- a/feature/home/src/main/java/com/hankki/feature/home/component/HankkiFilterBottomSheet.kt
+++ b/feature/home/src/main/java/com/hankki/feature/home/component/HankkiFilterBottomSheet.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hankki.core.common.amplitude.EventType
 import com.hankki.core.common.amplitude.LocalTracker
+import com.hankki.core.common.amplitude.PropertyKey
 import com.hankki.core.common.extension.noRippleClickable
 import com.hankki.core.designsystem.theme.Gray200
 import com.hankki.core.designsystem.theme.Gray800
@@ -94,8 +95,8 @@ fun HankkiFilterBottomSheet(
                         type = EventType.COMPLETED,
                         name = "Home_Detail_Filter",
                         properties = mapOf(
-                            "정렬" to nowSortedName.value.name,
-                            "가격대" to nowPriceName.value.name
+                            PropertyKey.ARRAY to nowSortedName.value.name,
+                            PropertyKey.PRICE to nowPriceName.value.name
                         )
                     )
                 },

--- a/feature/home/src/main/java/com/hankki/feature/home/component/HankkiFilterBottomSheet.kt
+++ b/feature/home/src/main/java/com/hankki/feature/home/component/HankkiFilterBottomSheet.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.hankki.core.common.amplitude.EventType
+import com.hankki.core.common.amplitude.LocalTracker
 import com.hankki.core.common.extension.noRippleClickable
 import com.hankki.core.designsystem.theme.Gray200
 import com.hankki.core.designsystem.theme.Gray800
@@ -41,6 +43,8 @@ fun HankkiFilterBottomSheet(
     onDismissRequest: () -> Unit = {},
     onSubmit: (ChipItem, ChipItem) -> Unit = { _, _ -> },
 ) {
+    val tracker = LocalTracker.current
+
     val nowPriceName = remember { mutableStateOf(selectedPriceItem) }
     val nowSortedName = remember { mutableStateOf(selectedSortItem) }
 
@@ -86,6 +90,14 @@ fun HankkiFilterBottomSheet(
                 .padding(top = 14.dp, bottom = 4.dp)
                 .noRippleClickable {
                     onSubmit(nowPriceName.value, nowSortedName.value)
+                    tracker.track(
+                        type = EventType.COMPLETED,
+                        name = "Home_Detail_Filter",
+                        properties = mapOf(
+                            "정렬" to nowSortedName.value.name,
+                            "가격대" to nowPriceName.value.name
+                        )
+                    )
                 },
             color = Gray800,
             textAlign = TextAlign.Center,

--- a/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
@@ -155,6 +155,16 @@ fun MyJogboDetailScreen(
     val scrollState = rememberLazyListState()
     val context = LocalContext.current
 
+    if (isSharedJogbo && !isJogboOwner) {
+        tracker.track(
+            type = EventType.NONE,
+            name = "Shared_Jokbo_Page",
+            properties = mapOf(
+                "족보" to jogboTitle
+            )
+        )
+    }
+
     if (shareDialogState) {
         DoubleButtonDialog(
             title = stringResource(R.string.no_jogbo),

--- a/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
@@ -352,7 +352,16 @@ fun MyJogboDetailScreen(
                             .fillMaxWidth()
                             .padding(bottom = 15.dp),
                         text = stringResource(R.string.add_to_my_jogbo),
-                        onClick = { navigateToNewSharedJogbo(isSharedJogbo, favoriteId) },
+                        onClick = {
+                            navigateToNewSharedJogbo(isSharedJogbo, favoriteId)
+                            tracker.track(
+                                type = EventType.ADD,
+                                name = "Shared_Jokbo_MyJokbo",
+                                properties = mapOf(
+                                    "족보" to jogboTitle
+                                )
+                            )
+                        },
                         enabled = true,
                         textStyle = HankkiTheme.typography.sub3,
                     )

--- a/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
@@ -33,6 +33,7 @@ import androidx.lifecycle.flowWithLifecycle
 import com.hankki.core.common.BuildConfig.KAKAO_SHARE_DEFAULT_IMAGE
 import com.hankki.core.common.amplitude.EventType
 import com.hankki.core.common.amplitude.LocalTracker
+import com.hankki.core.common.amplitude.PropertyKey
 import com.hankki.core.common.extension.noRippleClickable
 import com.hankki.core.common.utill.EmptyUiState
 import com.hankki.core.designsystem.component.button.HankkiButton
@@ -160,7 +161,7 @@ fun MyJogboDetailScreen(
             type = EventType.NONE,
             name = "Shared_Jokbo_Page",
             properties = mapOf(
-                "족보" to jogboTitle
+                PropertyKey.JOGBO to jogboTitle
             )
         )
     }
@@ -248,7 +249,7 @@ fun MyJogboDetailScreen(
                                             type = EventType.COMPLETED,
                                             name = "Mypage_MyJokbo_Share",
                                             properties = mapOf(
-                                                "족보" to jogboTitle
+                                                PropertyKey.JOGBO to jogboTitle
                                             )
                                         )
                                     }
@@ -258,7 +259,7 @@ fun MyJogboDetailScreen(
                                     type = EventType.NONE,
                                     name = "Mypage_MyJokbo_Share",
                                     properties = mapOf(
-                                        "족보" to jogboTitle
+                                        PropertyKey.JOGBO to jogboTitle
                                     )
                                 )
                             }
@@ -367,7 +368,7 @@ fun MyJogboDetailScreen(
                                 type = EventType.ADD,
                                 name = "Shared_Jokbo_MyJokbo",
                                 properties = mapOf(
-                                    "족보" to jogboTitle
+                                    PropertyKey.JOGBO to jogboTitle
                                 )
                             )
                         },

--- a/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
@@ -138,7 +138,7 @@ fun MyJogboDetailScreen(
     navigateToHome: () -> Unit,
     navigateToNewSharedJogbo: (Boolean, Long) -> Unit,
     isSharedJogbo: Boolean,
-    shareJogbo: (Context, String, String, String, Long) -> Unit,
+    shareJogbo: (Context, String, String, String, Long, () -> Unit) -> Unit,
     favoriteId: Long,
     isJogboOwner: Boolean,
     loginDialogState: Boolean,
@@ -242,7 +242,16 @@ fun MyJogboDetailScreen(
                                     imageUrl,
                                     jogboTitle,
                                     userName,
-                                    favoriteId
+                                    favoriteId,
+                                    {
+                                        tracker.track(
+                                            type = EventType.COMPLETED,
+                                            name = "Mypage_MyJokbo_Share",
+                                            properties = mapOf(
+                                                "족보" to jogboTitle
+                                            )
+                                        )
+                                    }
                                 )
 
                                 tracker.track(

--- a/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailRoute.kt
@@ -31,6 +31,8 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import com.hankki.core.common.BuildConfig.KAKAO_SHARE_DEFAULT_IMAGE
+import com.hankki.core.common.amplitude.EventType
+import com.hankki.core.common.amplitude.LocalTracker
 import com.hankki.core.common.extension.noRippleClickable
 import com.hankki.core.common.utill.EmptyUiState
 import com.hankki.core.designsystem.component.button.HankkiButton
@@ -144,7 +146,9 @@ fun MyJogboDetailScreen(
     navigateToLogin: (Boolean) -> Unit,
     navigateToMyJogbo: (Boolean) -> Unit
 ) {
+    val tracker = LocalTracker.current
     val configuration = LocalConfiguration.current
+
     val height by rememberSaveable {
         mutableDoubleStateOf(configuration.screenHeightDp * 0.09)
     }
@@ -217,7 +221,7 @@ fun MyJogboDetailScreen(
                             jogboChips = jogboChips,
                             userName = userName,
                             navigateToMyJogbo = navigateToMyJogbo,
-                            shareJogboDialogState = {
+                            onClickShareButton = {
                                 val defaultImageUrl = KAKAO_SHARE_DEFAULT_IMAGE
                                 val imageUrl =
                                     state.data.firstOrNull { it.imageUrl != null }?.imageUrl
@@ -229,6 +233,14 @@ fun MyJogboDetailScreen(
                                     jogboTitle,
                                     userName,
                                     favoriteId
+                                )
+
+                                tracker.track(
+                                    type = EventType.NONE,
+                                    name = "Mypage_MyJokbo_Share",
+                                    properties = mapOf(
+                                        "족보" to jogboTitle
+                                    )
                                 )
                             }
                         )
@@ -285,7 +297,7 @@ fun MyJogboDetailScreen(
                             jogboChips = jogboChips,
                             userName = userName,
                             navigateToMyJogbo = navigateToMyJogbo,
-                            shareJogboDialogState = updateShareDialogState
+                            onClickShareButton = updateShareDialogState
                         )
 
                         Spacer(modifier = Modifier.height((height).dp))

--- a/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailViewModel.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/MyJogboDetailViewModel.kt
@@ -133,7 +133,8 @@ class MyJogboDetailViewModel @Inject constructor(
         image: String,
         title: String,
         senderName: String,
-        favoriteId: Long
+        favoriteId: Long,
+        trackResult: () -> Unit
     ) {
         val templateId = 115383L
         val templateArgs = mapOf(
@@ -149,6 +150,7 @@ class MyJogboDetailViewModel @Inject constructor(
                     Timber.e(error)
                 } else if (result != null) {
                     context.startActivity(result.intent)
+                    trackResult()
                 }
             }
         } else {

--- a/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/component/JogboFolder.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/component/JogboFolder.kt
@@ -39,7 +39,7 @@ fun JogboFolder(
     title: String,
     chips: PersistentList<String>,
     userName: String,
-    shareJogboDialogState: () -> Unit,
+    onClickShareButton: () -> Unit,
     isJogboOwner: Boolean,
     modifier: Modifier = Modifier
 ) {
@@ -117,7 +117,7 @@ fun JogboFolder(
                 JogboShareButton(
                     modifier = Modifier.alpha(if (isJogboOwner) 1f else 0f),
                     showShareDialog = {
-                        if (isJogboOwner) shareJogboDialogState() else {
+                        if (isJogboOwner) onClickShareButton() else {
                         }
                     }
                 )
@@ -135,7 +135,7 @@ fun JogboFolderPreview() {
                 title = "족보 이름",
                 chips = persistentListOf("태그1", "태그2"),
                 userName = "사용자 이름",
-                shareJogboDialogState = {},
+                onClickShareButton = {},
                 isJogboOwner = false
             )
 
@@ -143,7 +143,7 @@ fun JogboFolderPreview() {
                 title = "족보 이름",
                 chips = persistentListOf("태그1", "태그2"),
                 userName = "사용자 이름",
-                shareJogboDialogState = {},
+                onClickShareButton = {},
                 isJogboOwner = true
             )
         }

--- a/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/component/JogboHeader.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/myjogbodetail/component/JogboHeader.kt
@@ -31,7 +31,7 @@ fun JogboHeader(
     jogboChips: PersistentList<String>,
     userName: String,
     navigateToMyJogbo: (Boolean) -> Unit,
-    shareJogboDialogState: () -> Unit
+    onClickShareButton: () -> Unit
 ) {
     HankkiTopBar(
         modifier = Modifier
@@ -61,7 +61,7 @@ fun JogboHeader(
         title = jogboTitle,
         chips = jogboChips,
         userName = userName,
-        shareJogboDialogState = shareJogboDialogState,
+        onClickShareButton = onClickShareButton,
         isJogboOwner = isJogboOwner
     )
 }
@@ -77,7 +77,7 @@ fun JogboHeaderPreview() {
             jogboChips = persistentListOf(),
             userName = "nickname",
             navigateToMyJogbo = {},
-            shareJogboDialogState = {}
+            onClickShareButton = {}
         )
     }
 }

--- a/feature/my/src/main/java/com/hankki/feature/my/newjogbo/NewJogboRoute.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/newjogbo/NewJogboRoute.kt
@@ -32,6 +32,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
+import com.hankki.core.common.amplitude.EventType
+import com.hankki.core.common.amplitude.LocalTracker
 import com.hankki.core.common.extension.addFocusCleaner
 import com.hankki.core.common.extension.noRippleClickable
 import com.hankki.core.designsystem.component.button.HankkiButton
@@ -115,6 +117,7 @@ fun NewJogboScreen(
 ) {
     val isVisibleIme = WindowInsets.isImeVisible
     val focusManager = LocalFocusManager.current
+    val tracker = LocalTracker.current
 
     if (errorDialogState) {
         SingleButtonDialog(
@@ -210,7 +213,16 @@ fun NewJogboScreen(
                     .fillMaxWidth()
                     .imePadding(),
                 text = if (isSharedJogbo) stringResource(R.string.add) else stringResource(R.string.make_jogbo),
-                onClick = { createSharedJogbo(favoriteId) },
+                onClick = {
+                    createSharedJogbo(favoriteId)
+                    tracker.track(
+                        type = EventType.COMPLETED,
+                        name = "Shared_Jokbo_MyJokbo_Add",
+                        properties = mapOf(
+                            "족보" to title
+                        )
+                    )
+                },
                 enabled = buttonEnabledState,
                 textStyle = HankkiTheme.typography.sub3,
             )
@@ -222,7 +234,16 @@ fun NewJogboScreen(
                     .fillMaxWidth()
                     .padding(bottom = 15.dp),
                 text = if (isSharedJogbo) stringResource(R.string.add) else stringResource(R.string.make_jogbo),
-                onClick = { createNewJogbo() },
+                onClick = {
+                    createNewJogbo()
+                    tracker.track(
+                        type = EventType.COMPLETED,
+                        name = "Shared_Jokbo_MyJokbo_Add",
+                        properties = mapOf(
+                            "족보" to title
+                        )
+                    )
+                },
                 enabled = buttonEnabledState,
                 textStyle = HankkiTheme.typography.sub3,
             )

--- a/feature/my/src/main/java/com/hankki/feature/my/newjogbo/NewJogboRoute.kt
+++ b/feature/my/src/main/java/com/hankki/feature/my/newjogbo/NewJogboRoute.kt
@@ -34,6 +34,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import com.hankki.core.common.amplitude.EventType
 import com.hankki.core.common.amplitude.LocalTracker
+import com.hankki.core.common.amplitude.PropertyKey
 import com.hankki.core.common.extension.addFocusCleaner
 import com.hankki.core.common.extension.noRippleClickable
 import com.hankki.core.designsystem.component.button.HankkiButton
@@ -219,7 +220,7 @@ fun NewJogboScreen(
                         type = EventType.COMPLETED,
                         name = "Shared_Jokbo_MyJokbo_Add",
                         properties = mapOf(
-                            "족보" to title
+                            PropertyKey.JOGBO to title
                         )
                     )
                 },
@@ -240,7 +241,7 @@ fun NewJogboScreen(
                         type = EventType.COMPLETED,
                         name = "Shared_Jokbo_MyJokbo_Add",
                         properties = mapOf(
-                            "족보" to title
+                            PropertyKey.JOGBO to title
                         )
                     )
                 },

--- a/feature/report/src/main/java/com/hankki/feature/report/main/ReportRoute.kt
+++ b/feature/report/src/main/java/com/hankki/feature/report/main/ReportRoute.kt
@@ -53,6 +53,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import com.hankki.core.common.amplitude.EventType
 import com.hankki.core.common.amplitude.LocalTracker
+import com.hankki.core.common.amplitude.PropertyKey
 import com.hankki.core.common.extension.addFocusCleaner
 import com.hankki.core.common.extension.animateScrollAroundItem
 import com.hankki.core.common.extension.noRippleClickable
@@ -480,7 +481,7 @@ fun StoreCategoryChips(
                                 type = EventType.CLICK,
                                 name = "Report_Food_Categories",
                                 properties = mapOf(
-                                    "food" to item.name
+                                    PropertyKey.FOOD to item.name
                                 )
                             )
                         }

--- a/feature/report/src/main/java/com/hankki/feature/report/main/ReportRoute.kt
+++ b/feature/report/src/main/java/com/hankki/feature/report/main/ReportRoute.kt
@@ -1,6 +1,7 @@
 package com.hankki.feature.report.main
 
 import android.net.Uri
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -190,11 +191,22 @@ fun ReportScreen(
     controlErrorDialog: () -> Unit = {},
     submitReport: () -> Unit,
 ) {
+    val tracker = LocalTracker.current
+    val focusManager = LocalFocusManager.current
+
     val coroutineScope = rememberCoroutineScope()
     val scrollState = rememberScrollState()
-    val focusManager = LocalFocusManager.current
+
     val isVisibleIme = WindowInsets.isImeVisible
-    val tracker = LocalTracker.current
+
+    BackHandler {
+        navigateUp()
+
+        tracker.track(
+            type = EventType.CLICK,
+            name = "Report_Back"
+        )
+    }
 
     if (isUniversityError) {
         SingleButtonDialog(
@@ -231,6 +243,7 @@ fun ReportScreen(
                         .size(44.dp)
                         .noRippleClickable {
                             navigateUp()
+
                             tracker.track(
                                 type = EventType.CLICK,
                                 name = "Report_Back"

--- a/feature/report/src/main/java/com/hankki/feature/report/main/ReportRoute.kt
+++ b/feature/report/src/main/java/com/hankki/feature/report/main/ReportRoute.kt
@@ -429,6 +429,8 @@ fun StoreCategoryChips(
     selectedItem: String?,
     onClick: (String) -> Unit = {},
 ) {
+    val tracker = LocalTracker.current
+
     Column(modifier = Modifier.fillMaxWidth()) {
         Text(
             text = title,
@@ -446,7 +448,16 @@ fun StoreCategoryChips(
                         iconUrl = item.imageUrl,
                         title = item.name,
                         isSelected = item.tag == selectedItem,
-                        onClick = { onClick(item.tag) }
+                        onClick = {
+                            onClick(item.tag)
+                            tracker.track(
+                                type = EventType.CLICK,
+                                name = "Report_Food_Categories",
+                                properties = mapOf(
+                                    "food" to item.name
+                                )
+                            )
+                        }
                     )
                 }
             }

--- a/feature/report/src/main/java/com/hankki/feature/report/main/ReportRoute.kt
+++ b/feature/report/src/main/java/com/hankki/feature/report/main/ReportRoute.kt
@@ -194,6 +194,7 @@ fun ReportScreen(
     val scrollState = rememberScrollState()
     val focusManager = LocalFocusManager.current
     val isVisibleIme = WindowInsets.isImeVisible
+    val tracker = LocalTracker.current
 
     if (isUniversityError) {
         SingleButtonDialog(
@@ -292,7 +293,13 @@ fun ReportScreen(
                         if (selectedImageUri == null) {
                             Spacer(modifier = Modifier.height(24.dp))
                             AddPhotoButton(
-                                onClick = selectImageUri,
+                                onClick = {
+                                    selectImageUri()
+                                    tracker.track(
+                                        type = EventType.CLICK,
+                                        name = "Report_Food_Picture"
+                                    )
+                                },
                                 modifier = Modifier.fillMaxWidth()
                             )
                             Spacer(modifier = Modifier.height(24.dp))

--- a/feature/report/src/main/java/com/hankki/feature/report/main/ReportRoute.kt
+++ b/feature/report/src/main/java/com/hankki/feature/report/main/ReportRoute.kt
@@ -229,7 +229,13 @@ fun ReportScreen(
                     modifier = Modifier
                         .padding(start = 9.dp)
                         .size(44.dp)
-                        .noRippleClickable(navigateUp)
+                        .noRippleClickable {
+                            navigateUp()
+                            tracker.track(
+                                type = EventType.CLICK,
+                                name = "Report_Back"
+                            )
+                        }
                 )
             }
         )

--- a/feature/report/src/main/java/com/hankki/feature/report/main/ReportRoute.kt
+++ b/feature/report/src/main/java/com/hankki/feature/report/main/ReportRoute.kt
@@ -134,6 +134,14 @@ fun ReportRoute(
                     )
                 }
 
+                is ReportSideEffect.NavigateUpTrack -> {
+                    navigateUp()
+                    tracker.track(
+                        type = EventType.CLICK,
+                        name = "Report_Back"
+                    )
+                }
+
                 ReportSideEffect.UniversityError -> navigateUp()
                 ReportSideEffect.ReportError -> snackBar("오류가 발생했어요. 다시 시도해주세요")
             }
@@ -146,7 +154,7 @@ fun ReportRoute(
         buttonEnabled = state.buttonEnabled,
         isShowErrorDialog = state.isShowErrorDialog,
         controlErrorDialog = viewModel::controlErrorDialog,
-        navigateUp = navigateUp,
+        navigateUp = viewModel::navigateUpTrackSideEffect,
         categoryList = state.categoryList,
         selectedImageUri = state.selectedImageUri,
         isUniversityError = state.isUniversityError,
@@ -163,7 +171,7 @@ fun ReportRoute(
         addMenu = viewModel::addMenu,
         deleteMenu = viewModel::deleteMenu,
         navigateSearchStore = navigateSearchStore,
-        submitReport = viewModel::submitReport
+        submitReport = viewModel::submitReport,
     )
 }
 
@@ -200,14 +208,7 @@ fun ReportScreen(
 
     val isVisibleIme = WindowInsets.isImeVisible
 
-    BackHandler {
-        navigateUp()
-
-        tracker.track(
-            type = EventType.CLICK,
-            name = "Report_Back"
-        )
-    }
+    BackHandler(onBack = navigateUp)
 
     if (isUniversityError) {
         SingleButtonDialog(
@@ -242,14 +243,7 @@ fun ReportScreen(
                     modifier = Modifier
                         .padding(start = 9.dp)
                         .size(44.dp)
-                        .noRippleClickable {
-                            navigateUp()
-
-                            tracker.track(
-                                type = EventType.CLICK,
-                                name = "Report_Back"
-                            )
-                        }
+                        .noRippleClickable(navigateUp)
                 )
             }
         )

--- a/feature/report/src/main/java/com/hankki/feature/report/main/ReportSideEffect.kt
+++ b/feature/report/src/main/java/com/hankki/feature/report/main/ReportSideEffect.kt
@@ -10,4 +10,6 @@ sealed class ReportSideEffect {
     data object UniversityError : ReportSideEffect()
 
     data object ReportError : ReportSideEffect()
+
+    data object NavigateUpTrack: ReportSideEffect()
 }

--- a/feature/report/src/main/java/com/hankki/feature/report/main/ReportViewModel.kt
+++ b/feature/report/src/main/java/com/hankki/feature/report/main/ReportViewModel.kt
@@ -3,7 +3,6 @@ package com.hankki.feature.report.main
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.hankki.domain.report.entity.request.ReportStoreRequestEntity
 import com.hankki.domain.report.repository.ReportRepository
 import com.hankki.feature.report.model.LocationModel

--- a/feature/report/src/main/java/com/hankki/feature/report/main/ReportViewModel.kt
+++ b/feature/report/src/main/java/com/hankki/feature/report/main/ReportViewModel.kt
@@ -3,6 +3,7 @@ package com.hankki.feature.report.main
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.hankki.domain.report.entity.request.ReportStoreRequestEntity
 import com.hankki.domain.report.repository.ReportRepository
 import com.hankki.feature.report.model.LocationModel
@@ -213,6 +214,12 @@ class ReportViewModel @Inject constructor(
             _state.value = _state.value.copy(
                 isShowErrorDialog = !state.value.isShowErrorDialog
             )
+        }
+    }
+
+    fun navigateUpTrackSideEffect(){
+        viewModelScope.launch {
+            _sideEffect.emit(ReportSideEffect.NavigateUpTrack)
         }
     }
 }

--- a/feature/report/src/main/java/com/hankki/feature/report/searchstore/SearchStoreRoute.kt
+++ b/feature/report/src/main/java/com/hankki/feature/report/searchstore/SearchStoreRoute.kt
@@ -30,6 +30,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
+import com.hankki.core.common.amplitude.EventType
+import com.hankki.core.common.amplitude.LocalTracker
 import com.hankki.core.common.extension.addFocusCleaner
 import com.hankki.core.common.extension.noRippleClickable
 import com.hankki.core.common.utill.EmptyUiState
@@ -116,6 +118,7 @@ fun SearchStoreScreen(
     reportButtonClicked: () -> Unit = {},
     onDismissDialog: () -> Unit = {},
 ) {
+    val tracker = LocalTracker.current
     val focusManager = LocalFocusManager.current
 
     if (isOpenDialog) {
@@ -246,6 +249,10 @@ fun SearchStoreScreen(
                     ),
                     onClick = {
                         reportButtonClicked()
+                        tracker.track(
+                            type = EventType.CLICK,
+                            name = "Report_RestaurantComplete"
+                        )
                     },
                     modifier = Modifier
                         .fillMaxWidth()

--- a/feature/storedetail/src/main/java/com/hankki/feature/storedetail/StoreDetailRoute.kt
+++ b/feature/storedetail/src/main/java/com/hankki/feature/storedetail/StoreDetailRoute.kt
@@ -246,6 +246,7 @@ fun StoreDetailScreen(
     onEditMenuClick: () -> Unit
 ) {
     val localContextResource = LocalContext.current.resources
+    val tracker = LocalTracker.current
 
     if (isOpenBottomSheet) {
         HankkiStoreJogboBottomSheet(
@@ -409,7 +410,13 @@ fun StoreDetailScreen(
 
             StoreDetailMenuBox(
                 menuItems = menuItems,
-                onMenuEditClick = openEditMenuBottomSheet
+                onMenuEditClick = {
+                    openEditMenuBottomSheet()
+                    tracker.track(
+                        type = EventType.CLICK,
+                        name = "RestInfo_MenuEdit"
+                    )
+                }
             )
 
             Spacer(modifier = Modifier.height(20.dp))

--- a/feature/storedetail/src/main/java/com/hankki/feature/storedetail/StoreDetailRoute.kt
+++ b/feature/storedetail/src/main/java/com/hankki/feature/storedetail/StoreDetailRoute.kt
@@ -43,13 +43,12 @@ import com.hankki.core.common.utill.UiState
 import com.hankki.core.designsystem.R
 import com.hankki.core.designsystem.component.bottomsheet.HankkiStoreJogboBottomSheet
 import com.hankki.core.designsystem.component.bottomsheet.JogboResponseModel
-import com.hankki.feature.storedetail.component.StoreDetailMenuButton
 import com.hankki.core.designsystem.component.dialog.DoubleButtonDialog
 import com.hankki.core.designsystem.component.dialog.ImageDoubleButtonDialog
 import com.hankki.core.designsystem.component.layout.HankkiLoadingScreen
 import com.hankki.core.designsystem.component.topappbar.HankkiTopBar
-import com.hankki.core.designsystem.event.LocalSnackBarTrigger
 import com.hankki.core.designsystem.event.LocalButtonSnackBarTrigger
+import com.hankki.core.designsystem.event.LocalSnackBarTrigger
 import com.hankki.core.designsystem.theme.Gray100
 import com.hankki.core.designsystem.theme.Gray350
 import com.hankki.core.designsystem.theme.Gray400
@@ -62,6 +61,7 @@ import com.hankki.domain.storedetail.entity.MenuItem
 import com.hankki.feature.storedetail.component.StoreDetailDifferentButton
 import com.hankki.feature.storedetail.component.StoreDetailHeadBox
 import com.hankki.feature.storedetail.component.StoreDetailMenuBox
+import com.hankki.feature.storedetail.component.StoreDetailMenuButton
 import com.hankki.feature.storedetail.editbottomsheet.EditMenuBottomSheet
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
@@ -311,7 +311,13 @@ fun StoreDetailScreen(
                             contentDescription = "뒤로가기",
                             modifier = Modifier
                                 .padding(start = 6.dp, top = 2.dp)
-                                .noRippleClickable(onClick = onNavigateUp),
+                                .noRippleClickable(onClick = {
+                                    onNavigateUp()
+                                    tracker.track(
+                                        type = EventType.CLICK,
+                                        name = "RestInfo_Back"
+                                    )
+                                }),
                             tint = Gray50
                         )
                     }

--- a/feature/storedetail/src/main/java/com/hankki/feature/storedetail/StoreDetailRoute.kt
+++ b/feature/storedetail/src/main/java/com/hankki/feature/storedetail/StoreDetailRoute.kt
@@ -1,5 +1,6 @@
 package com.hankki.feature.storedetail
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -247,6 +248,15 @@ fun StoreDetailScreen(
 ) {
     val localContextResource = LocalContext.current.resources
     val tracker = LocalTracker.current
+
+    BackHandler {
+        onNavigateUp()
+
+        tracker.track(
+            type = EventType.CLICK,
+            name = "RestInfo_Back"
+        )
+    }
 
     if (isOpenBottomSheet) {
         HankkiStoreJogboBottomSheet(

--- a/feature/storedetail/src/main/java/com/hankki/feature/storedetail/editbottomsheet/add/addmenu/AddMenuRoute.kt
+++ b/feature/storedetail/src/main/java/com/hankki/feature/storedetail/editbottomsheet/add/addmenu/AddMenuRoute.kt
@@ -18,6 +18,8 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hankki.core.common.amplitude.EventType
+import com.hankki.core.common.amplitude.LocalTracker
 import com.hankki.core.common.extension.noRippleClickable
 import com.hankki.core.designsystem.component.button.HankkiButton
 import com.hankki.core.designsystem.component.textfield.HankkiMenuTextField
@@ -91,6 +93,7 @@ private fun AddMenuScreen(
     onSubmit: () -> Unit
 ) {
     val focusManager = LocalFocusManager.current
+    val tracker = LocalTracker.current
 
     Column(
         modifier = Modifier
@@ -207,7 +210,13 @@ private fun AddMenuScreen(
             Spacer(modifier = Modifier.height(12.dp))
             HankkiButton(
                 text = "${menuList.size}개 추가하기",
-                onClick = onSubmit,
+                onClick = {
+                    onSubmit()
+                    tracker.track(
+                        type = EventType.CLICK,
+                        name = "RestInfo_MenuAddCompleted"
+                    )
+                },
                 enabled = buttonEnabled,
                 modifier = Modifier.fillMaxWidth(),
                 textStyle = HankkiTheme.typography.sub3

--- a/feature/storedetail/src/main/java/com/hankki/feature/storedetail/editbottomsheet/edit/editmenu/EditMenuRoute.kt
+++ b/feature/storedetail/src/main/java/com/hankki/feature/storedetail/editbottomsheet/edit/editmenu/EditMenuRoute.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hankki.core.common.amplitude.EventType
+import com.hankki.core.common.amplitude.LocalTracker
 import com.hankki.core.common.extension.noRippleClickable
 import com.hankki.core.designsystem.component.dialog.DoubleButtonDialog
 import com.hankki.core.designsystem.component.layout.BottomBlurLayout
@@ -53,6 +55,8 @@ fun EditMenuRoute(
     onNavigateToDeleteSuccessLast: (Long) -> Unit,
 ) {
     val snackBar = LocalSnackBarTrigger.current
+    val tracker = LocalTracker.current
+
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val dialogState by viewModel.dialogState.collectAsStateWithLifecycle()
 
@@ -91,6 +95,10 @@ fun EditMenuRoute(
                 onPositiveButtonClicked = {
                     viewModel.deleteMenuItem(storeId)
                     viewModel.closeDialog()
+                    tracker.track(
+                        type = EventType.CLICK,
+                        name = "RestInfo_DeleteCompleted"
+                    )
                 }
             )
         }

--- a/feature/storedetail/src/main/java/com/hankki/feature/storedetail/editbottomsheet/edit/editmenu/EditMenuRoute.kt
+++ b/feature/storedetail/src/main/java/com/hankki/feature/storedetail/editbottomsheet/edit/editmenu/EditMenuRoute.kt
@@ -114,6 +114,10 @@ fun EditMenuRoute(
                 onPositiveButtonClicked = {
                     viewModel.deleteMenuItem(storeId)
                     viewModel.closeDialog()
+                    tracker.track(
+                        type = EventType.CLICK,
+                        name = "RestInfo_DeleteCompleted"
+                    )
                 }
             )
         }

--- a/feature/storedetail/src/main/java/com/hankki/feature/storedetail/editbottomsheet/edit/mod/ModRoute.kt
+++ b/feature/storedetail/src/main/java/com/hankki/feature/storedetail/editbottomsheet/edit/mod/ModRoute.kt
@@ -117,6 +117,10 @@ fun ModRoute(
                 onPositiveButtonClicked = {
                     viewModel.deleteMenu()
                     viewModel.closeDialog()
+                    tracker.track(
+                        type = EventType.CLICK,
+                        name = "RestInfo_DeleteCompleted"
+                    )
                 }
             )
         }

--- a/feature/storedetail/src/main/java/com/hankki/feature/storedetail/editbottomsheet/edit/mod/ModRoute.kt
+++ b/feature/storedetail/src/main/java/com/hankki/feature/storedetail/editbottomsheet/edit/mod/ModRoute.kt
@@ -29,6 +29,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hankki.core.common.amplitude.EventType
+import com.hankki.core.common.amplitude.LocalTracker
 import com.hankki.core.common.extension.noRippleClickable
 import com.hankki.core.designsystem.component.button.HankkiExpandedButton
 import com.hankki.core.designsystem.component.button.HankkiMediumButton
@@ -60,6 +62,7 @@ fun ModRoute(
     onNavigateToDeleteSuccess: (Long) -> Unit,
 ) {
     val snackBar = LocalSnackBarTrigger.current
+    val tracker = LocalTracker.current
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val sideEffectFlow = viewModel.sideEffect
@@ -131,6 +134,10 @@ fun ModRoute(
                         viewModel.submitMenu()
                     }
                     viewModel.closeDialog()
+                    tracker.track(
+                        type = EventType.CLICK,
+                        name = "RestInfo_MenuEditCompleted"
+                    )
                 }
             )
         }

--- a/feature/universityselection/src/main/java/com/hankki/feature/universityselection/UniversitySelectionRoute.kt
+++ b/feature/universityselection/src/main/java/com/hankki/feature/universityselection/UniversitySelectionRoute.kt
@@ -29,6 +29,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import com.hankki.core.common.amplitude.EventType
 import com.hankki.core.common.amplitude.LocalTracker
+import com.hankki.core.common.amplitude.PropertyKey
 import com.hankki.core.common.extension.noRippleClickable
 import com.hankki.core.common.utill.UiState
 import com.hankki.core.designsystem.component.button.HankkiButton
@@ -67,7 +68,7 @@ fun UniversitySelectionRoute(
                             type = EventType.CLICK,
                             name = "UniversityChoice_AnyUniv",
                             properties = mapOf(
-                                "university" to sideEffect.universityName
+                                PropertyKey.UNIVERSITY to sideEffect.universityName
                             )
                         )
                     }


### PR DESCRIPTION
## *📌 Issue*
- closed #300

## *⛳️ Work Description*
- 기획에서 제시한 앰플리튜드를 모두 붙였습니다! 
- 항목은 구글 스프레스 시트에 있는데 찾기 어려우시다면 링크 보내드릴게요!

## *📸 Screenshot*
<img src="https://github.com/user-attachments/assets/796ff51b-9b73-487b-8373-830de6576466" width="700" />

## *📢 To Reviewers*
- 300번째 이슈는 제가 가져갑니당 ㅋㅋ
- 앰플리튜드는 이렇게 구현하는거군요 신기한 세계! 단순반복이라서 재밌었다 ㅎㅎ
- 뒤로가기에도 앰플리튜드를 붙여야해서 BackHandler를 통해 구현했는데,다른 방법으로도 구현이 가능한지 궁금합니다..!
  - 탑바와 백핸들러 모두 동일한 코드를 사용하는데 어떻게 하면 더 단순하게 구현할 수 있을지 여러 생각이 들어요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced user interaction tracking across multiple screens (home, report, store details, etc.) by logging events for clicks, shares, back navigation, and menu actions.
  - Introduced new property keys for tracking events, enhancing clarity and maintainability.
  - Added new event types such as `COMPLETED` and `NONE` for more granular tracking.

- **Refactor**
  - Updated callback signatures and renamed parameters in sharing and interaction components to improve clarity and support analytics tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->