### PR TITLE
[Feature/#304] image접근에 관련된 권한을 제거합니다.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,6 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
 
     <application


### PR DESCRIPTION
## *📌 Issue*
- closed #304 

## *⛳️ Work Description*
- 권한 제거

## *📢 To Reviewers*
- 구글 정책을 반영하기 위해 이미지 접근 permission을 제거했습니다.
- 구글 기본 ImagePicker를 사용하면 없어도 되는 permission이라 기존 기능에 문제 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated app permissions to remove automatic access to media images. This change may affect how images from your device’s library are accessed, enhancing your privacy and control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->